### PR TITLE
Add "HasNotPassed" assertion

### DIFF
--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/AbstractProcessAssertTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/AbstractProcessAssertTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Martin Schimak <martin.schimak@plexiti.com>

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineAssertionsTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineAssertionsTest.java
@@ -12,8 +12,6 @@ import org.mockito.Mockito;
 
 
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.*;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.assertThat;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.processEngine;
 
 /**
  * @author Martin Schimak <martin.schimak@plexiti.com>

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineTestsClaimTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineTestsClaimTest.java
@@ -1,7 +1,6 @@
 package org.camunda.bpm.engine.test.assertions;
 
 import org.camunda.bpm.engine.runtime.ProcessInstance;
-import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.assertions.helpers.Failure;

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineTestsWithVariablesTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessEngineTestsWithVariablesTest.java
@@ -7,7 +7,6 @@ import org.junit.runners.Parameterized;
 import java.util.*;
 
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Martin Schimak <martin.schimak@plexiti.com>

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessInstanceAssertHasNotPassedTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/ProcessInstanceAssertHasNotPassedTest.java
@@ -1,0 +1,114 @@
+package org.camunda.bpm.engine.test.assertions;
+
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.assertions.helpers.Failure;
+import org.camunda.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+
+/**
+ * @author Johannes Beck (mail@johannes-beck.name)
+ */
+public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase {
+
+  @Rule
+  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Test
+  @Deployment(resources = {
+    "ProcessInstanceAssert-hasPassed.bpmn"
+  })
+  public void testHasNotPassed_OnlyActivity_RunningInstance_Success() {
+    // Given
+    final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
+      "ProcessInstanceAssert-hasPassed"
+    );
+    // When
+    complete(taskQuery().singleResult());
+    // Then
+    expect(new Failure() {
+      @Override
+      public void when() {
+        assertThat(processInstance).hasNotPassed("UserTask_1");
+      }
+    });
+  }
+
+  @Test
+  @Deployment(resources = {
+    "ProcessInstanceAssert-hasPassed.bpmn"
+  })
+  public void testHasNotPassed_OnlyActivity_RunningInstance_Failure() {
+    // When
+    final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
+      "ProcessInstanceAssert-hasPassed"
+    );
+    // Then
+    assertThat(processInstance).hasNotPassed("UserTask_1");
+    // And
+    assertThat(processInstance).hasNotPassed("UserTask_2", "UserTask_3", "UserTask_4");
+  }
+
+  @Test
+  @Deployment(resources = {
+    "ProcessInstanceAssert-hasPassed.bpmn"
+  })
+  public void testHasNotPassed_ParallelActivities_RunningInstance_Failure() {
+    // Given
+    final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
+      "ProcessInstanceAssert-hasPassed"
+    );
+    // When
+    complete(taskQuery().singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_2").singleResult());
+    // Then
+    assertThat(processInstance).hasNotPassed("UserTask_3");
+    // And
+    assertThat(processInstance).hasNotPassed("UserTask_4");
+  }
+
+  @Test
+  @Deployment(resources = {
+    "ProcessInstanceAssert-hasPassed.bpmn"
+  })
+  public void testHasNotPassed_SeveralActivities_RunningInstance_Failure() {
+    // Given
+    final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
+      "ProcessInstanceAssert-hasPassed"
+    );
+    // When
+    complete(taskQuery().singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_2").singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_3").singleResult());
+    // Then
+    assertThat(processInstance).hasNotPassed("UserTask_4");
+  }
+
+  @Test
+  @Deployment(resources = {
+    "ProcessInstanceAssert-hasPassed.bpmn"
+  })
+  public void testHasNotPassed_SeveralActivities_HistoricInstance_Failure() {
+    // Given
+    final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
+      "ProcessInstanceAssert-hasPassed"
+    );
+    // When
+    complete(taskQuery().singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_2").singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_3").singleResult());
+    // And
+    complete(taskQuery().taskDefinitionKey("UserTask_4").singleResult());
+    // Then
+    assertThat(processInstance).hasNotPassed("UserTask_5");
+  }
+}


### PR DESCRIPTION
Hi,

I've added a convenience method for checking that a process instance has not passed a list of given activities; which is the inverse of "hasPassed". 

Regards,
Joe
