### PR TITLE
Fix hasCandidateGroup does not work when task is assigned (issue #53)

### DIFF
--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/TaskAssertHasCandidateGroupTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/TaskAssertHasCandidateGroupTest.java
@@ -252,4 +252,21 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
     });
   }
 
+
+  @Test
+  @Deployment(resources = {
+    "TaskAssert-hasCandidateGroup.bpmn"
+  })
+  public void testHasCandidateGroup_WithAssignee() {
+    // Given
+    runtimeService().startProcessInstanceByKey(
+      "TaskAssert-hasCandidateGroup"
+    );
+    // When
+    final Task task = taskQuery().singleResult();
+    claim(task, "assignee");
+    // Then
+    assertThat(task).hasCandidateGroup("candidateGroup");
+  }
+
 }


### PR DESCRIPTION
With camunda 7.1 it is not possible to check on a candidate group when the user task is already claimed, because the taskQuery() API does not allow this. This would change with 7.2, where includeAssignedTasks was introduced.

Since we do not want to change the camuda version, I came up with a native query, accessing ACT_RU_IDENTITYLINK directly. We get a list of actual candidateGroupIds and check (ListAssert) if this list contains the value we want to check. Since this uses ListAssert.contains(...) anyway, I extended the API to allow hasCandidateGroups(...), so we can check multiple candidateGroups at once.

To keep the API symetric, I applied the same pattern to hasCandidateUser/hasCandidateUsers.

Added new test to verify expected behaviour and made sure all existing tests are green.

Some remarks:

I know that using native queries instead of API requires some getting used to, but:

* I do not see any harm in using a native sql query here, because camunda is known to keep the schema stable, it is very unlikely that this will ever change. And if it would, we can assume that this would mean something very basic in the task/identitylink relation changed which almost certain would required adopting the used taskQuery API as well.
* From a performance point of view, this even improves, since it is still one query as before, but it allows checking multiple ids at once.
* In the given error message we can now see the actual groups/users instead of just "expected to have ...., but found it doesn't".