### PR TITLE
feat(assertApi): enable agile assertions development across Camunda BPM versions

### DIFF
--- a/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/assertions/AbstractProcessAssert.java
+++ b/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/assertions/AbstractProcessAssert.java
@@ -10,9 +10,9 @@ import org.camunda.bpm.engine.runtime.JobQuery;
 import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
 import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
 import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.engine.test.util.CamundaBpmApi;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Martin Schimak <martin.schimak@plexiti.com>
@@ -85,6 +85,24 @@ public abstract class AbstractProcessAssert<S extends AbstractProcessAssert<S, A
     if (asserts == null)
       lastAsserts.set(asserts = new HashMap<Class<?>, AbstractProcessAssert>());
     return asserts;
+  }
+
+  /*
+   * Asserts that process engine supports the requested API version. Use method
+   * at the beginning of assertion implementations which require Camunda BPM API
+   * versions higher than Camunda BPM "7.0".
+   * 
+   * @param   api Camunda BPM API version e.g. '7.1', '7.2' etc.
+   * @throws  AssertionError if process engine does not support the requested API version
+   */
+  protected static void assertApi(String api) {
+    if (!CamundaBpmApi.supports(api)) {
+      throw new AssertionError(String.format("Requested method requires Camunda BPM %s or higher.", api));
+    }
+  }
+
+  protected static boolean supportsApi(String api) {
+    return CamundaBpmApi.supports(api);
   }
 
   protected RepositoryService repositoryService() {

--- a/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/assertions/ProcessEngineAssertions.java
+++ b/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/assertions/ProcessEngineAssertions.java
@@ -7,6 +7,7 @@ import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 
 import org.assertj.core.api.Assertions;
+import org.camunda.bpm.engine.test.util.CamundaBpmApi;
 
 import java.util.Map;
 
@@ -23,6 +24,22 @@ public class ProcessEngineAssertions extends Assertions {
   static ThreadLocal<ProcessEngine> processEngine = new ThreadLocal<ProcessEngine>();
 
   protected ProcessEngineAssertions() {
+  }
+
+  /*
+   * *Asserts* that process engine supports the requested API version. Use method
+   * at the beginning of static helper method implementations which require 
+   * Camunda BPM API versions higher than Camunda BPM "7.0".
+   * 
+   * @param   api Camunda BPM API version e.g. '7.1', '7.2' etc.
+   * @throws  AssertionError if process engine does not support the requested API version
+   */
+  protected static void assertApi(String api) {
+    AbstractProcessAssert.assertApi(api);
+  }
+
+  protected static boolean supportsApi(String api) {
+    return CamundaBpmApi.supports(api);
   }
 
   /**

--- a/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/util/CamundaBpmApi.java
+++ b/camunda-bpm-assert/src/main/java/org/camunda/bpm/engine/test/util/CamundaBpmApi.java
@@ -1,0 +1,43 @@
+package org.camunda.bpm.engine.test.util;
+
+import org.assertj.core.api.Assertions;
+
+import java.util.*;
+
+/**
+ * @author Martin Schimak <martin.schimak@plexiti.com>
+ */
+public class CamundaBpmApi {
+
+  private static Map<String, String> markerClasses = new HashMap<String, String>();
+
+  static {
+    markerClasses.put("7.0", "org.camunda.bpm.engine.ProcessEngine");
+    markerClasses.put("7.1", "org.camunda.bpm.engine.management.JobDefinitionQuery");
+    markerClasses.put("7.2", "org.camunda.bpm.engine.CaseService");
+    markerClasses.put("7.3", "org.camunda.bpm.engine.runtime.ProcessInstanceModificationBuilder");
+    markerClasses.put("7.4", "org.camunda.bpm.dmn.engine.DmnEngine");
+  }
+
+  /**
+   * Answers, if process engine supports the requested API version.
+   *
+   * @param   api Camunda BPM API version e.g. '7.1', '7.2' etc.
+   * @return  true, if process engine supports the requested API version.          
+   */
+  public static boolean supports(String api) {
+    List<String> apis = new ArrayList<String>(markerClasses.keySet());
+    Collections.sort(apis);
+    Assertions.assertThat(apis)
+      .overridingErrorMessage(String.format("Unknown API version %s requested, currently "
+        + "just %s are supported.", api, apis))
+      .contains(api);
+    try {
+      Class.forName(markerClasses.get(api));
+    } catch (ClassNotFoundException e) {
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/AssertApiTest.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/AssertApiTest.java
@@ -1,0 +1,32 @@
+package org.camunda.bpm.engine.test.assertions;
+
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
+import org.camunda.bpm.engine.test.util.CamundaBpmApi;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+
+/**
+ * @author Martin Schimak <martin.schimak@plexiti.com>
+ */
+public class AssertApiTest extends ProcessAssertTestCase {
+
+  @Rule
+  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+  @Test
+  public void testSupports74Api() {
+    assumeApi("7.4");
+    assertApi("7.4");
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testNotSupports74Api() {
+    Assume.assumeFalse(CamundaBpmApi.supports("7.4"));
+    assertApi("7.4");
+  }
+
+}

--- a/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
+++ b/camunda-bpm-assert/src/test/java/org/camunda/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
@@ -2,6 +2,8 @@ package org.camunda.bpm.engine.test.assertions.helpers;
 
 
 import org.assertj.core.util.Lists;
+import org.camunda.bpm.engine.test.util.CamundaBpmApi;
+import org.junit.Assume;
 
 import static org.assertj.core.api.Assertions.fail;
 
@@ -28,6 +30,21 @@ public abstract class ProcessAssertTestCase {
       throw (RuntimeException) e;
     }
     fail("expected one of " + Lists.newArrayList(exception) + " to be thrown, but did not see any");
+  }
+
+  /*
+   * *Assumes* that process engine supports the requested API version. Use method
+   * at the beginning of test method implementations which require Camunda BPM API
+   * versions higher than Camunda BPM "7.0". Alternatively use it e.g. in @Before 
+   * annotated methods for whole test classes. This will cause your test methods to 
+   * be IGNORED, when executing it against a Camunda BPM engine older than needed.
+   * 
+   * @param   api Camunda BPM API version e.g. '7.1', '7.2' etc.
+   * @throws  AssumptionViolatedException if process engine does not support the 
+   *          requested API version
+   */
+  protected void assumeApi(String api) {
+    Assume.assumeTrue(CamundaBpmApi.supports(api));
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,13 @@
     </modules>
 
     <properties>
-        <camunda-bpm.version>7.1.0-Final</camunda-bpm.version> 
-        <!-- also works with 7.0.0-Final and any newer version, just use it with your own version -->
+        <camunda-bpm.version>RELEASE</camunda-bpm.version> 
+
+        <!-- 
+            Camunda BPM Assert simply works - with all released versions of 
+            Camunda BPM Platform, just use it with the version you need! 
+        -->
+        
         <camunda-bpm-assert.version>${project.version}</camunda-bpm-assert.version>
 
         <version.slf4j>1.7.2</version.slf4j>


### PR DESCRIPTION
**Camunda BPM Assert** still grows, becomes more mature ... but development slowed down. Why is that? Well, it's not lack of dedication, but I admit I felt a bit blocked recently, first without knowing conciously. I think I know now. A day of being sick in the bed brought me some time and enlightenment. :smile: 

Camunda BPM Assert will continue to remain community driven. This means:

1. The assertions which run against e.g. Camunda BPM 7.0 are still far from being "feature complete" when comparing it with the many possibilities of Camunda BPM's 7.0 API. Of course that's ok, people will add or at least request what they need and would like to use.
1. Camunda BPM's latest and greatest features (e.g. 7.2 and 7.4 bring a lot of them in the areas of CMMN and DMN) bring a lot of developer motivation to contribute new assertions, too, as e.g. pending pull request #52 prooves. 

There is a certain tension in between **1** and **2**. In an "ideal" world ...

* ... highly motivated contributors to Camunda BPM Assert should be able to work against the most recent API without asking or feeling stuck with an old API...
* ... but the releases of Camunda BPM Assert should be able to support at least the most recent and supported Camunda BPM versions as well...
* ... and contributing and maintaining Camunda BPM Assert must remain really **simple** (which excludes several branches as overkill) but also **safe** (which e.g. means that a new assertion dealing with 7.2 API should not accidentally use a 7.4 API without actually needing it) 

I came up with the following relatively **unconventional solution** provided here as pull request to foster community feedback. But I believe for Camunda BPM Assert's 'nature' and requirements the following approach would work really well:

1. We continue to maintain just **one simple master branch**, but from now on it always compiles and builds against Camunda BPM's latest "RELEASE" (which includes alpha releases).

2. When **implementing** assertions (or little static helpers), we transparently **document** and **assert** for the user that the code needs at least a specific API version:

    ```java
    /**
    * @Since Camunda BPM 7.2
    */
    public StageAssert isActive() {
      assertApi("7.2");
      // ...
    }
    ```

    (Find the implementation of assertApi() here: https://github.com/camunda/camunda-bpm-assert/commit/a3066f7fa7d206198552103c475e27f30b48cb58)

3. [NOTE: section **edited at Nov 16**, some of the discussion below is obsolete because of this edit] When **testing** assertions (or little static helpers), we **assume** (with an implementation based on the JUnit Assumptions API) that the test of course also needs the requested Camunda BPM API:

    ```java
    public void testStageAssertIsActive() {
      assumeApi("7.2");
      // ...
    }
    ```

With that, explicitly requested test executions against "old" Camunda BPM API versions are still possible via commandline properties, which is important for CI/Jenkins testing all those old versions. Such a build then automatically IGNORES those tests which need a newer Camunda BPM API. This is the intended effect of JUnit Assumptions raising a AssumptionViolatedException. This way, by simply testing the master against all Camunda BPM versions, the CI always makes sure that all assertions and helpers work down to the minimum Camunda API they claim to need.

I would love to get some feedback on this - but remember I am sick in the bed, so be honest, yes, but also nice and patient with me! :smile: 