### PR TITLE
Adapt CMMN assertion tests to CMMN 1.1 behaviour (fixes #95)

### DIFF
--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssert-variables.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssert-variables.cmmn
@@ -1,29 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssert-variables" name="CaseTaskAssert-variables Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssert-variables">
-  <cmmn:case id="Case_CaseTaskAssert-variables" name="CaseTaskAssert-variables Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssert-variables" name="CaseTaskAssert-variables Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssert-variables_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-    <cmmn:case id="Case_CaseTaskAssert-variables_CaseB" name="CaseTaskAssert-variables Test CaseB">
-      <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssert-variables_CaseB" name="CaseTaskAssert-variables Test CaseB">
-        <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB"/>
-        <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-          <cmmn:defaultControl>
-            <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
-              <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-            </cmmn:manualActivationRule>
-          </cmmn:defaultControl>
-        </cmmn:humanTask>
-      </cmmn:casePlanModel>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssert-variables" name="CaseTaskAssert-variables Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssert-variables" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssert-variables" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssert-variables Test" id="Case_CaseTaskAssert-variables">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssert-variables Test" id="CPM_CaseTaskAssert-variables">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssert-variables_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+        </cmmn:casePlanModel>
     </cmmn:case>
+    <cmmn:case name="CaseTaskAssert-variables Test CaseB" id="Case_CaseTaskAssert-variables_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssert-variables Test CaseB" id="CPM_CaseTaskAssert-variables_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssert-variables Test" id="PCPM_CaseTaskAssert-variables" sharedStyle="a2ec763e-6dea-4540-824b-5850391ccc80">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssert-variables" id="_e30d785c-9e91-4b5b-bcdc-101155c83f2e">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_a4727245-5f5b-4e12-9d94-9c4b8766435b">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssert-variables Test CaseB" id="PCPM_CaseTaskAssert-variables_CaseB" sharedStyle="a2ec763e-6dea-4540-824b-5850391ccc80">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssert-variables_CaseB" id="_082f9909-1aeb-463c-916c-b0ccf5e552d9">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_ae0a6666-285a-4d15-a1dd-787decac3d59">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="a2ec763e-6dea-4540-824b-5850391ccc80"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsActiveTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsActiveTest.cmmn
@@ -1,29 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsActiveTest" name="CaseTaskAssertIsActive Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsActiveTest">
-  <cmmn:case id="Case_CaseTaskAssertIsActiveTest" name="CaseTaskAssertIsActive Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsActiveTest" name="CaseTaskAssertIsActive Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsActiveTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsActiveTest_CaseB" name="CaseTaskAssertIsActive Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsActiveTest_CaseB" name="CaseTaskAssertIsActive Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsActiveTest" name="CaseTaskAssertIsActive Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsActiveTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsActiveTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsActive Test" id="Case_CaseTaskAssertIsActiveTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsActive Test" id="CPM_CaseTaskAssertIsActiveTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsActiveTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsActive Test CaseB" id="Case_CaseTaskAssertIsActiveTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsActive Test CaseB" id="CPM_CaseTaskAssertIsActiveTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsActive Test" id="PCPM_CaseTaskAssertIsActiveTest" sharedStyle="_68263501-51fe-4980-821e-fc060d3d69db">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsActiveTest" id="_9358a03d-bb93-4cd7-a5a8-6c74f92ef1a3">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_9d4031ec-9b3b-45e7-87b9-2e60e822e226">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsActive Test CaseB" id="PCPM_CaseTaskAssertIsActiveTest_CaseB" sharedStyle="_68263501-51fe-4980-821e-fc060d3d69db">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsActiveTest_CaseB" id="_6069111c-247c-4d98-8094-3af095dec13e">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_7b6c7945-d1b3-4b9b-ab11-7a974b8e7979">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_68263501-51fe-4980-821e-fc060d3d69db"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsAvailableTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsAvailableTest.cmmn
@@ -1,42 +1,81 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsAvailableTest" name="CaseTaskAssertIsAvailable Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsAvailableTest">
-  <cmmn:case id="Case_CaseTaskAssertIsAvailableTest" name="CaseTaskAssertIsAvailable Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsAvailableTest" name="CaseTaskAssertIsAvailable Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="CT_TaskB" entryCriteriaRefs="On_PI_CT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_CT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsAvailableTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-      <cmmn:caseTask description="" id="CT_TaskB" isBlocking="true" name="B" caseRef="Case_CaseTaskAssertIsAvailableTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d2" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsAvailableTest_CaseB" name="CaseTaskAssertIsAvailable Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsAvailableTest_CaseB" name="CaseTaskAssertIsAvailable Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB_HT"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsAvailableTest" name="CaseTaskAssertIsAvailable Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsAvailableTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsAvailableTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsAvailable Test" id="Case_CaseTaskAssertIsAvailableTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsAvailable Test" id="CPM_CaseTaskAssertIsAvailableTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_CT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_CT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_35da68f9-ff21-4b42-8376-cb7d161d6f2b">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsAvailableTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsAvailableTest_CaseB" isBlocking="true" name="B" id="PID_PI_TaskB">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d2">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsAvailable Test CaseB" id="Case_CaseTaskAssertIsAvailableTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsAvailable Test CaseB" id="CPM_CaseTaskAssertIsAvailableTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB_HT" id="PI_TaskB_HT"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB_HT">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsAvailable Test" id="PCPM_CaseTaskAssertIsAvailableTest" sharedStyle="_2f573658-08cb-4d28-9cba-a936414203b3">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsAvailableTest" id="_cabcce50-af22-4e5f-b83e-ee82caedf113">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_2cee5d8f-006a-44a4-b972-e3b533a52ee1">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_919132fb-be16-4da1-80df-483b2ce54136">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_b6fb4f7c-9d30-4bb3-bff6-e5d15b7e557b">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_35da68f9-ff21-4b42-8376-cb7d161d6f2b" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_dcddf803-8606-43b0-94b8-9d8503ac2b1c">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsAvailable Test CaseB" id="PCPM_CaseTaskAssertIsAvailableTest_CaseB" sharedStyle="_2f573658-08cb-4d28-9cba-a936414203b3">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsAvailableTest_CaseB" id="_2aba7338-3abd-40d3-b125-19f4e08fefb5">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB_HT" id="_e24a9f72-d70d-4369-84f9-9ef2d3d44ed1">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_2f573658-08cb-4d28-9cba-a936414203b3"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsCompletedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsCompletedTest.cmmn
@@ -1,29 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsCompletedTest" name="CaseTaskAssertIsCompleted Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsCompletedTest">
-  <cmmn:case id="Case_CaseTaskAssertIsCompletedTest" name="CaseTaskAssertIsCompleted Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsCompletedTest" name="CaseTaskAssertIsCompleted Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsCompletedTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsCompletedTest_CaseB" name="CaseTaskAssertIsCompleted Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsCompletedTest_CaseB" name="CaseTaskAssertIsCompleted Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsCompletedTest" name="CaseTaskAssertIsCompleted Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsCompletedTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsCompletedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsCompleted Test" id="Case_CaseTaskAssertIsCompletedTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsCompleted Test" id="CPM_CaseTaskAssertIsCompletedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsCompletedTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsCompleted Test CaseB" id="Case_CaseTaskAssertIsCompletedTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsCompleted Test CaseB" id="CPM_CaseTaskAssertIsCompletedTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsCompleted Test" id="PCPM_CaseTaskAssertIsCompletedTest" sharedStyle="_95924bb0-d0e2-4da3-bc0c-18cf66fdf834">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsCompletedTest" id="_37af37a5-d837-42af-b8c2-4edee6ed6bc6">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_df07530f-acbb-4298-9282-f50bdde5654b">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsCompleted Test CaseB" id="PCPM_CaseTaskAssertIsCompletedTest_CaseB" sharedStyle="_95924bb0-d0e2-4da3-bc0c-18cf66fdf834">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsCompletedTest_CaseB" id="_1473aa18-267a-4734-87f2-6ce4186ade24">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_aaf88e2f-b1c2-4ffc-b600-74a46ee17061">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_95924bb0-d0e2-4da3-bc0c-18cf66fdf834"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsDisabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsDisabledTest.cmmn
@@ -1,24 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsDisabledTest" name="CaseTaskAssertIsDisabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsDisabledTest">
-  <cmmn:case id="Case_CaseTaskAssertIsDisabledTest" name="CaseTaskAssertIsDisabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsDisabledTest" name="CaseTaskAssertIsDisabled Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsDisabledTest_CaseB">
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsDisabledTest_CaseB" name="CaseTaskAssertIsDisabled Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsDisabledTest_CaseB" name="CaseTaskAssertIsDisabled Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a921">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions exporter="Camunda Modeler" id="Test" name="CaseTaskAssertIsDisabledTest" targetNamespace="http://bpmn.io/schema/cmmn" xmlns="http://bpmn.io/schema/cmmn" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsDisabled Test" id="Case_CaseTaskAssertIsDisabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsDisabled Test" id="CPM_CaseTaskAssertIsDisabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsDisabledTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="ManualActivationRule_0noww12">
+                        <cmmn:condition id="Expression_0twwiui">${true}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsDisabled Test CaseB" id="Case_CaseTaskAssertIsDisabledTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsDisabled Test CaseB&#10;&#10;" id="CPM_CaseTaskAssertIsDisabledTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="ManualActivationRule_1xissx7">
+                        <cmmn:condition id="Expression_10rydqt">${true}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Page 0" id="_5a66685b-5f57-4e2f-b1d1-acca4fae04b2" sharedStyle="_4d4d2f54-bd40-4dba-b0f3-701a71dc1088">
+            <cmmndi:Size height="500.0" width="500.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsDisabledTest" id="DI_CasePlanModel_1">
+                <dc:Bounds height="389.0" width="534.0" x="114.0" y="63.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="PlanItem_1b4kl2o_di">
+                <dc:Bounds height="80.0" width="100.0" x="150.0" y="96.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsDisabledTest_CaseB" id="CasePlanModel_0row8py_di">
+                <dc:Bounds height="250.0" width="400.0" x="715.0" y="92.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="PlanItem_1uwrc15_di">
+                <dc:Bounds height="80.0" width="100.0" x="776.0" y="175.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_4d4d2f54-bd40-4dba-b0f3-701a71dc1088"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsEnabledTest.cmmn
@@ -1,75 +1,78 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="CaseTaskAssertIsEnabled Test" id="Case_CaseTaskAssertIsEnabledTest">
-        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsEnabled Test" id="CPM_CaseTaskAssertIsEnabledTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:entryCriterion sentryRef="On_PI_CT_A_Complete" id="N65560_entry1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_CT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_0d009401-28e9-44bf-83e1-9ed1b4d269aa">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:caseTask>
-            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB" isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmn:case name="CaseTaskAssertIsEnabled Test CaseB" id="Case_CaseTaskAssertIsEnabledTest_CaseB">
-        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsEnabled Test CaseB" id="CPM_CaseTaskAssertIsEnabledTest_CaseB">
-            <cmmn:planItem definitionRef="PID_PI_TaskB_HT" id="PI_TaskB_HT"/>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB_HT">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:humanTask>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="CaseTaskAssertIsEnabled Test" id="PCPM_CaseTaskAssertIsEnabledTest" sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest" id="_2de6ce08-a61f-4c92-867a-7632c7bdc125">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_0ab2c0a3-aca6-44b2-88e3-1be82863b8b6">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_81e7e96f-600e-4972-a69a-a557d029e107">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_82b1ec8a-a5c6-4c67-bbd2-6c35ab65a5ae">
-                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="_0d009401-28e9-44bf-83e1-9ed1b4d269aa" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_7e18b05a-1935-473b-9f7c-ab58efea67d4">
-                <di:waypoint x="286.0" y="228.0"/>
-                <di:waypoint x="346.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNDiagram name="CaseTaskAssertIsEnabled Test CaseB" id="PCPM_CaseTaskAssertIsEnabledTest_CaseB" sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc">
-            <cmmndi:Size height="500.0" width="550.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest_CaseB" id="_5f51079c-b95b-4561-9f8e-afc7008f6651">
-                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB_HT" id="_2e864ad3-a85d-411f-a768-9397de0c9ad8">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="a30d1f59-e696-4438-a917-d9d21ebaaccc"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test">
+    <cmmn:casePlanModel id="CPM_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:itemControl id="PlanItemControl_14nmeyk">
+          <cmmn:manualActivationRule id="ManualActivationRule_1tt6zpz">
+            <cmmn:condition id="Expression_0mnz2km">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:entryCriterion id="N65560_entry1" sentryRef="On_PI_CT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_CT_A_Complete">
+        <cmmn:planItemOnPart id="_0d009401-28e9-44bf-83e1-9ed1b4d269aa" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:caseTask id="PID_PI_TaskA" name="A" caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB">
+        <cmmn:defaultControl>
+          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel">#{false}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:defaultControl>
+      </cmmn:caseTask>
+      <cmmn:caseTask id="PID_PI_TaskB" name="B" caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmn:case id="Case_CaseTaskAssertIsEnabledTest_CaseB" name="CaseTaskAssertIsEnabled Test CaseB">
+    <cmmn:casePlanModel id="CPM_CaseTaskAssertIsEnabledTest_CaseB" name="CaseTaskAssertIsEnabled Test CaseB" autoComplete="false">
+      <cmmn:planItem id="PI_TaskB_HT" definitionRef="PID_PI_TaskB_HT" />
+      <cmmn:humanTask id="PID_PI_TaskB_HT" name="A">
+        <cmmn:defaultControl>
+          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
+            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel">#{false}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:defaultControl>
+      </cmmn:humanTask>
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc" id="PCPM_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_2de6ce08-a61f-4c92-867a-7632c7bdc125" cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_0ab2c0a3-aca6-44b2-88e3-1be82863b8b6" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_81e7e96f-600e-4972-a69a-a557d029e107" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_82b1ec8a-a5c6-4c67-bbd2-6c35ab65a5ae" cmmnElementRef="N65560_entry1">
+        <dc:Bounds x="346" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_7e18b05a-1935-473b-9f7c-ab58efea67d4" cmmnElementRef="_0d009401-28e9-44bf-83e1-9ed1b4d269aa" targetCMMNElementRef="N65560_entry1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="286" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="346" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNDiagram sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc" id="PCPM_CaseTaskAssertIsEnabledTest_CaseB" name="CaseTaskAssertIsEnabled Test CaseB">
+      <cmmndi:Size xsi:type="dc:Dimension" width="550" height="500" />
+      <cmmndi:CMMNShape id="_5f51079c-b95b-4561-9f8e-afc7008f6651" cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest_CaseB">
+        <dc:Bounds x="150" y="150" width="250" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_2e864ad3-a85d-411f-a768-9397de0c9ad8" cmmnElementRef="PI_TaskB_HT">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="a30d1f59-e696-4438-a917-d9d21ebaaccc" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsEnabledTest.cmmn
@@ -1,37 +1,75 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest">
-  <cmmn:case id="Case_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="CT_TaskB" entryCriteriaRefs="On_PI_CT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_CT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-      <cmmn:caseTask description="" id="CT_TaskB" isBlocking="true" name="B" caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB">
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsEnabledTest_CaseB" name="CaseTaskAssertIsEnabled Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsEnabledTest_CaseB" name="CaseTaskAssertIsEnabled Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB_HT"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsEnabledTest" name="CaseTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsEnabled Test" id="Case_CaseTaskAssertIsEnabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsEnabled Test" id="CPM_CaseTaskAssertIsEnabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_CT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_CT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_0d009401-28e9-44bf-83e1-9ed1b4d269aa">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsEnabledTest_CaseB" isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsEnabled Test CaseB" id="Case_CaseTaskAssertIsEnabledTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsEnabled Test CaseB" id="CPM_CaseTaskAssertIsEnabledTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB_HT" id="PI_TaskB_HT"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB_HT">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsEnabled Test" id="PCPM_CaseTaskAssertIsEnabledTest" sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest" id="_2de6ce08-a61f-4c92-867a-7632c7bdc125">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_0ab2c0a3-aca6-44b2-88e3-1be82863b8b6">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_81e7e96f-600e-4972-a69a-a557d029e107">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_82b1ec8a-a5c6-4c67-bbd2-6c35ab65a5ae">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_0d009401-28e9-44bf-83e1-9ed1b4d269aa" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_7e18b05a-1935-473b-9f7c-ab58efea67d4">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsEnabled Test CaseB" id="PCPM_CaseTaskAssertIsEnabledTest_CaseB" sharedStyle="a30d1f59-e696-4438-a917-d9d21ebaaccc">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsEnabledTest_CaseB" id="_5f51079c-b95b-4561-9f8e-afc7008f6651">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB_HT" id="_2e864ad3-a85d-411f-a768-9397de0c9ad8">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="a30d1f59-e696-4438-a917-d9d21ebaaccc"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsTerminatedTest.cmmn
@@ -1,37 +1,75 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest">
-  <cmmn:case id="Case_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test">
-      <cmmn:planItem definitionRef="CT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="CT_TaskB" exitCriteriaRefs="On_PI_CT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_CT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:caseTask description="" id="CT_TaskA" isBlocking="true" name="A" caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:caseTask>
-      <cmmn:caseTask description="" id="CT_TaskB" isBlocking="true" name="B" caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB">
-      </cmmn:caseTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
-  <cmmn:case id="Case_CaseTaskAssertIsTerminatedTest_CaseB" name="CaseTaskAssertIsTerminated Test CaseB">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_CaseTaskAssertIsTerminatedTest_CaseB" name="CaseTaskAssertIsTerminated Test CaseB">
-      <cmmn:planItem definitionRef="HT_TaskB" id="PI_TaskB_HT"/>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="CaseTaskAssertIsTerminated Test" id="Case_CaseTaskAssertIsTerminatedTest">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsTerminated Test" id="CPM_CaseTaskAssertIsTerminatedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:exitCriterion sentryRef="On_PI_CT_A_Complete" id="N65560_exit1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_CT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:caseTask>
+            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB" isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmn:case name="CaseTaskAssertIsTerminated Test CaseB" id="Case_CaseTaskAssertIsTerminatedTest_CaseB">
+        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsTerminated Test CaseB" id="CPM_CaseTaskAssertIsTerminatedTest_CaseB">
+            <cmmn:planItem definitionRef="PID_PI_TaskB_HT" id="PI_TaskB_HT"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB_HT">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsTerminated Test" id="PCPM_CaseTaskAssertIsTerminatedTest" sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest" id="_fc6ee96e-33bd-432f-aa8c-c2389fa235b7">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_edabe773-1221-472b-b004-70cda4954c38">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_95e208e5-b583-42f1-a913-6ce9dcc59f68">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_exit1" id="_64880c54-a212-4b17-afd5-842149751023">
+                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58" isStandardEventVisible="true" targetCMMNElementRef="N65560_exit1" id="_3d469e85-3807-473b-aee9-474c8e78fcf4">
+                <di:waypoint x="296.0" y="228.0"/>
+                <di:waypoint x="356.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNDiagram name="CaseTaskAssertIsTerminated Test CaseB" id="PCPM_CaseTaskAssertIsTerminatedTest_CaseB" sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest_CaseB" id="_36a948df-2069-4dd9-b2f3-fb4a8d1494b1">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB_HT" id="_1f26adb2-80d2-48b5-979a-ea0d7fec50e3">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/CaseTaskAssertIsTerminatedTest.cmmn
@@ -1,75 +1,78 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="CaseTaskAssertIsTerminated Test" id="Case_CaseTaskAssertIsTerminatedTest">
-        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsTerminated Test" id="CPM_CaseTaskAssertIsTerminatedTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:exitCriterion sentryRef="On_PI_CT_A_Complete" id="N65560_exit1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_CT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB" isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:caseTask>
-            <cmmn:caseTask caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB" isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmn:case name="CaseTaskAssertIsTerminated Test CaseB" id="Case_CaseTaskAssertIsTerminatedTest_CaseB">
-        <cmmn:casePlanModel autoComplete="false" name="CaseTaskAssertIsTerminated Test CaseB" id="CPM_CaseTaskAssertIsTerminatedTest_CaseB">
-            <cmmn:planItem definitionRef="PID_PI_TaskB_HT" id="PI_TaskB_HT"/>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskB_HT">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:humanTask>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="CaseTaskAssertIsTerminated Test" id="PCPM_CaseTaskAssertIsTerminatedTest" sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest" id="_fc6ee96e-33bd-432f-aa8c-c2389fa235b7">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_edabe773-1221-472b-b004-70cda4954c38">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_95e208e5-b583-42f1-a913-6ce9dcc59f68">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_exit1" id="_64880c54-a212-4b17-afd5-842149751023">
-                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58" isStandardEventVisible="true" targetCMMNElementRef="N65560_exit1" id="_3d469e85-3807-473b-aee9-474c8e78fcf4">
-                <di:waypoint x="296.0" y="228.0"/>
-                <di:waypoint x="356.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNDiagram name="CaseTaskAssertIsTerminated Test CaseB" id="PCPM_CaseTaskAssertIsTerminatedTest_CaseB" sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df">
-            <cmmndi:Size height="500.0" width="550.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest_CaseB" id="_36a948df-2069-4dd9-b2f3-fb4a8d1494b1">
-                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB_HT" id="_1f26adb2-80d2-48b5-979a-ea0d7fec50e3">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/CaseTaskAssertIsTerminatedTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test">
+    <cmmn:casePlanModel id="CPM_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:itemControl id="PlanItemControl_1tqvwsd">
+          <cmmn:manualActivationRule id="ManualActivationRule_10rsqy2">
+            <cmmn:condition id="Expression_08fo767">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:exitCriterion id="N65560_exit1" sentryRef="On_PI_CT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_CT_A_Complete">
+        <cmmn:planItemOnPart id="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:caseTask id="PID_PI_TaskA" name="A" caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB">
+        <cmmn:defaultControl>
+          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel">#{false}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:defaultControl>
+      </cmmn:caseTask>
+      <cmmn:caseTask id="PID_PI_TaskB" name="B" caseRef="Case_CaseTaskAssertIsTerminatedTest_CaseB" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmn:case id="Case_CaseTaskAssertIsTerminatedTest_CaseB" name="CaseTaskAssertIsTerminated Test CaseB">
+    <cmmn:casePlanModel id="CPM_CaseTaskAssertIsTerminatedTest_CaseB" name="CaseTaskAssertIsTerminated Test CaseB" autoComplete="false">
+      <cmmn:planItem id="PI_TaskB_HT" definitionRef="PID_PI_TaskB_HT" />
+      <cmmn:humanTask id="PID_PI_TaskB_HT" name="A">
+        <cmmn:defaultControl>
+          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a922">
+            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45d1" language="juel">#{false}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:defaultControl>
+      </cmmn:humanTask>
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df" id="PCPM_CaseTaskAssertIsTerminatedTest" name="CaseTaskAssertIsTerminated Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_fc6ee96e-33bd-432f-aa8c-c2389fa235b7" cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_edabe773-1221-472b-b004-70cda4954c38" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_95e208e5-b583-42f1-a913-6ce9dcc59f68" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_64880c54-a212-4b17-afd5-842149751023" cmmnElementRef="N65560_exit1">
+        <dc:Bounds x="276" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_3d469e85-3807-473b-aee9-474c8e78fcf4" cmmnElementRef="d03158d7-a4dd-4bfd-9fc3-3c009ddc7c58" targetCMMNElementRef="N65560_exit1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="296" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="356" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNDiagram sharedStyle="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df" id="PCPM_CaseTaskAssertIsTerminatedTest_CaseB" name="CaseTaskAssertIsTerminated Test CaseB">
+      <cmmndi:Size xsi:type="dc:Dimension" width="550" height="500" />
+      <cmmndi:CMMNShape id="_36a948df-2069-4dd9-b2f3-fb4a8d1494b1" cmmnElementRef="CPM_CaseTaskAssertIsTerminatedTest_CaseB">
+        <dc:Bounds x="150" y="150" width="250" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_1f26adb2-80d2-48b5-979a-ea0d7fec50e3" cmmnElementRef="PI_TaskB_HT">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="d3b5546e-19a1-401f-8f1f-e3d1d5dd48df" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssert-variables.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssert-variables.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssert-variables" name="HumanTaskAssert-variables Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssert-variables">
-  <cmmn:case id="Case_HumanTaskAssert-variables" name="HumanTaskAssert-variables Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssert-variables" name="HumanTaskAssert-variables Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssert-variables" name="HumanTaskAssert-variables Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssert-variables" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssert-variables" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssert-variables Test" id="Case_HumanTaskAssert-variables">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssert-variables Test" id="CPM_HumanTaskAssert-variables">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssert-variables Test" id="PCPM_HumanTaskAssert-variables" sharedStyle="_4a73763a-ca94-4b12-89f8-1324620dbe45">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssert-variables" id="_c2350a22-b00e-4025-81f2-f7b8eb2c95ec">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_c6d533c8-0fd2-4359-86f9-d56381888844">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_4a73763a-ca94-4b12-89f8-1324620dbe45"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsActiveTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsActiveTest.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsActiveTest" name="HumanTaskAssertIsActive Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsActiveTest">
-  <cmmn:case id="Case_HumanTaskAssertIsActiveTest" name="HumanTaskAssertIsActive Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsActiveTest" name="HumanTaskAssertIsActive Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsActiveTest" name="HumanTaskAssertIsActive Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsActiveTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsActiveTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertIsActive Test" id="Case_HumanTaskAssertIsActiveTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsActive Test" id="CPM_HumanTaskAssertIsActiveTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertIsActive Test" id="PCPM_HumanTaskAssertIsActiveTest" sharedStyle="_6935a39c-58ed-46f8-944b-dd8fcf578a6a">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsActiveTest" id="_11dde4cc-5f67-493a-9090-b10bb826db7c">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_6ca6974d-1e29-4656-8c88-2e90ac894da8">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_6935a39c-58ed-46f8-944b-dd8fcf578a6a"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsAvailableTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsAvailableTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsAvailableTest" name="HumanTaskAssertIsAvailable Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsAvailableTest">
-  <cmmn:case id="Case_HumanTaskAssertIsAvailableTest" name="HumanTaskAssertIsAvailable Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsAvailableTest" name="HumanTaskAssertIsAvailable Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsAvailableTest" name="HumanTaskAssertIsAvailable Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsAvailableTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsAvailableTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertIsAvailable Test" id="Case_HumanTaskAssertIsAvailableTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsAvailable Test" id="CPM_HumanTaskAssertIsAvailableTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_094a5483-0f68-4393-9508-4faab3626276">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertIsAvailable Test" id="PCPM_HumanTaskAssertIsAvailableTest" sharedStyle="_989d7ae2-0d33-4ad7-9b63-2b2292c926ef">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsAvailableTest" id="_3514150e-7bbe-4b15-981f-4d1dc585b9fc">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_92fbc328-f8b3-452b-9406-8bd02a600a9f">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_aa5da780-ce0f-4bfc-9114-bbe17805e3b2">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_308def56-dc74-4e29-9c62-9d9828267ba3">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_094a5483-0f68-4393-9508-4faab3626276" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_6ecd36e0-046f-4811-9f13-d53afe97037a">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_989d7ae2-0d33-4ad7-9b63-2b2292c926ef"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsCompletedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsCompletedTest.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsCompletedTest" name="HumanTaskAssertIsCompleted Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsCompletedTest">
-  <cmmn:case id="Case_HumanTaskAssertIsCompletedTest" name="HumanTaskAssertIsCompleted Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsCompletedTest" name="HumanTaskAssertIsCompleted Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsCompletedTest" name="HumanTaskAssertIsCompleted Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsCompletedTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsCompletedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertIsCompleted Test" id="Case_HumanTaskAssertIsCompletedTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsCompleted Test" id="CPM_HumanTaskAssertIsCompletedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertIsCompleted Test" id="PCPM_HumanTaskAssertIsCompletedTest" sharedStyle="fb0fd999-321a-409a-9bdc-bec1e4f73633">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsCompletedTest" id="_92ac0be3-81f5-45ce-bd82-1870de3833fc">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_8bc884b6-f4ce-46a3-a4dc-7e5e40e8e6d5">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="fb0fd999-321a-409a-9bdc-bec1e4f73633"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsDisabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsDisabledTest.cmmn
@@ -1,12 +1,24 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest">
-  <cmmn:case id="Case_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertisDisabled Test" id="Case_HumanTaskAssertIsDisabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertisDisabled Test" id="CPM_HumanTaskAssertIsDisabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertisDisabled Test" id="PCPM_HumanTaskAssertIsDisabledTest" sharedStyle="_32d90c96-6336-4f03-946c-afd3a438b4bb">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsDisabledTest" id="_90ce5a8f-dbe6-467d-90e4-d9389b205cce">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_1000d092-dbdf-4bcf-a54d-33ea61048698">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_32d90c96-6336-4f03-946c-afd3a438b4bb"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsDisabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsDisabledTest.cmmn
@@ -1,24 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="HumanTaskAssertisDisabled Test" id="Case_HumanTaskAssertIsDisabledTest">
-        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertisDisabled Test" id="CPM_HumanTaskAssertIsDisabledTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="HumanTaskAssertisDisabled Test" id="PCPM_HumanTaskAssertIsDisabledTest" sharedStyle="_32d90c96-6336-4f03-946c-afd3a438b4bb">
-            <cmmndi:Size height="500.0" width="550.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsDisabledTest" id="_90ce5a8f-dbe6-467d-90e4-d9389b205cce">
-                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_1000d092-dbdf-4bcf-a54d-33ea61048698">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_32d90c96-6336-4f03-946c-afd3a438b4bb"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsDisabledTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test">
+    <cmmn:casePlanModel id="CPM_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA">
+        <cmmn:itemControl id="PlanItemControl_0f5byxe">
+          <cmmn:manualActivationRule id="ManualActivationRule_1afc7p1">
+            <cmmn:condition id="Expression_18hoqny">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:humanTask id="PID_PI_TaskA" name="A" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="_32d90c96-6336-4f03-946c-afd3a438b4bb" id="PCPM_HumanTaskAssertIsDisabledTest" name="HumanTaskAssertisDisabled Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="550" height="500" />
+      <cmmndi:CMMNShape id="_90ce5a8f-dbe6-467d-90e4-d9389b205cce" cmmnElementRef="CPM_HumanTaskAssertIsDisabledTest">
+        <dc:Bounds x="150" y="150" width="250" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_1000d092-dbdf-4bcf-a54d-33ea61048698" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="_32d90c96-6336-4f03-946c-afd3a438b4bb" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsEnabledTest.cmmn
@@ -1,52 +1,49 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="HumanTaskAssertIsEnabled Test" id="Case_HumanTaskAssertIsEnabledTest">
-        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsEnabled Test" id="CPM_HumanTaskAssertIsEnabledTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_HT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_74820b3f-3f34-4937-b337-285dce760c6f">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:humanTask>
-            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="HumanTaskAssertIsEnabled Test" id="PCPM_HumanTaskAssertIsEnabledTest" sharedStyle="b13850be-fa0f-4dd6-8ffd-50680f39f339">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsEnabledTest" id="_e9fa78d8-acc8-46fb-89d5-0cb8ccd77f4d">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_174cffcd-8173-4fe5-99cb-35b3e8f01aaa">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_c4a5b970-ea8a-487b-ad1e-048604a5b95e">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_ff5a6ba7-9e73-411a-b032-680b20bbdd3d">
-                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="_74820b3f-3f34-4937-b337-285dce760c6f" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_4134a5e5-5929-407e-a457-7374e42ae745">
-                <di:waypoint x="286.0" y="228.0"/>
-                <di:waypoint x="346.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b13850be-fa0f-4dd6-8ffd-50680f39f339"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test">
+    <cmmn:casePlanModel id="CPM_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:itemControl id="PlanItemControl_087on98">
+          <cmmn:manualActivationRule id="ManualActivationRule_1sez1a8">
+            <cmmn:condition id="Expression_0w38g8a">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:entryCriterion id="N65560_entry1" sentryRef="On_PI_HT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_A_Complete">
+        <cmmn:planItemOnPart id="_74820b3f-3f34-4937-b337-285dce760c6f" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:humanTask id="PID_PI_TaskA" name="A" />
+      <cmmn:humanTask id="PID_PI_TaskB" name="B" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="b13850be-fa0f-4dd6-8ffd-50680f39f339" id="PCPM_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_e9fa78d8-acc8-46fb-89d5-0cb8ccd77f4d" cmmnElementRef="CPM_HumanTaskAssertIsEnabledTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_174cffcd-8173-4fe5-99cb-35b3e8f01aaa" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_c4a5b970-ea8a-487b-ad1e-048604a5b95e" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_ff5a6ba7-9e73-411a-b032-680b20bbdd3d" cmmnElementRef="N65560_entry1">
+        <dc:Bounds x="346" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_4134a5e5-5929-407e-a457-7374e42ae745" cmmnElementRef="_74820b3f-3f34-4937-b337-285dce760c6f" targetCMMNElementRef="N65560_entry1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="286" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="346" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="b13850be-fa0f-4dd6-8ffd-50680f39f339" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsEnabledTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest">
-  <cmmn:case id="Case_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsEnabledTest" name="HumanTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertIsEnabled Test" id="Case_HumanTaskAssertIsEnabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsEnabled Test" id="CPM_HumanTaskAssertIsEnabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_74820b3f-3f34-4937-b337-285dce760c6f">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertIsEnabled Test" id="PCPM_HumanTaskAssertIsEnabledTest" sharedStyle="b13850be-fa0f-4dd6-8ffd-50680f39f339">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsEnabledTest" id="_e9fa78d8-acc8-46fb-89d5-0cb8ccd77f4d">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_174cffcd-8173-4fe5-99cb-35b3e8f01aaa">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_c4a5b970-ea8a-487b-ad1e-048604a5b95e">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_ff5a6ba7-9e73-411a-b032-680b20bbdd3d">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_74820b3f-3f34-4937-b337-285dce760c6f" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_4134a5e5-5929-407e-a457-7374e42ae745">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b13850be-fa0f-4dd6-8ffd-50680f39f339"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/HumanTaskAssertIsTerminatedTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_HumanTaskAssertIsTerminatedTest" name="HumanTaskAssertIsTerminated Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsTerminatedTest">
-  <cmmn:case id="Case_HumanTaskAssertIsTerminatedTest" name="HumanTaskAssertIsTerminated Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_HumanTaskAssertIsTerminatedTest" name="HumanTaskAssertIsTerminated Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" exitCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-      <cmmn:humanTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_HumanTaskAssertIsTerminatedTest" name="HumanTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsTerminatedTest" xmlns="http://www.trisotech.com/cmmn/definitions/HumanTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="HumanTaskAssertIsTerminated Test" id="Case_HumanTaskAssertIsTerminatedTest">
+        <cmmn:casePlanModel autoComplete="false" name="HumanTaskAssertIsTerminated Test" id="CPM_HumanTaskAssertIsTerminatedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:exitCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_exit1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="d0430edf-ca7b-421a-80a7-e0d064ba882d">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="HumanTaskAssertIsTerminated Test" id="PCPM_HumanTaskAssertIsTerminatedTest" sharedStyle="bcf3910a-b4cc-4fb5-9811-3727cc1c19b2">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_HumanTaskAssertIsTerminatedTest" id="_a24d93a9-937d-467c-be7c-c3e019cbc671">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_9ec25bab-e39f-41d0-8044-79b27bfb47aa">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_eeee5399-cd66-4a59-a1d5-ca1b685ac1cb">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_exit1" id="_7bf2115d-c0c0-4427-89d6-af25cb139537">
+                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="d0430edf-ca7b-421a-80a7-e0d064ba882d" isStandardEventVisible="true" targetCMMNElementRef="N65560_exit1" id="_eb4cd508-9d16-43c0-9e56-00572f4ed364">
+                <di:waypoint x="296.0" y="228.0"/>
+                <di:waypoint x="356.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="bcf3910a-b4cc-4fb5-9811-3727cc1c19b2"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsAvailableTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsAvailableTest.cmmn
@@ -1,34 +1,62 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
     <cmmn:case id="MilestoneAssertIsAvailableTest">
-    <cmmn:casePlanModel autoComplete="true" id="_b70a29d0-52f0-4f65-a1d1-47130791b832">
-            <cmmn:planItem definitionRef="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d" entryCriteriaRefs="_cf6057cb-b409-4363-a177-92df6bbee2b7" id="Milestone">
-                
+        <cmmn:casePlanModel autoComplete="true" id="_b70a29d0-52f0-4f65-a1d1-47130791b832">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_Milestone" id="Milestone">
+                <cmmn:entryCriterion sentryRef="_cf6057cb-b409-4363-a177-92df6bbee2b7" id="N65557_entry1"/>
             </cmmn:planItem>
             <cmmn:sentry id="_cf6057cb-b409-4363-a177-92df6bbee2b7">
-                <cmmn:planItemOnPart id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" sourceRef="PI_TaskA">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8">
                     <cmmn:standardEvent>complete</cmmn:standardEvent>
                 </cmmn:planItemOnPart>
             </cmmn:sentry>
-            <cmmn:humanTask id="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" isBlocking="true">
+            <cmmn:humanTask isBlocking="true" id="PID_PI_TaskA">
                 <cmmn:defaultControl>
                     <cmmn:requiredRule id="_7a98952a-a040-49a8-b479-1df83da3309e">
                         <cmmn:condition id="bbe1c437-0e31-4941-b556-d9380905b775">
-              <cmmn:body>${true}</cmmn:body>
+              ${true}
             </cmmn:condition>
                     </cmmn:requiredRule>
                     <cmmn:manualActivationRule id="e0b48876-fe8d-442f-8bf1-467db41846fe">
                         <cmmn:condition id="d5d8fcd6-1356-4685-9ef2-a477eaa98fb2">
-              <cmmn:body>${false}</cmmn:body>
+              ${false}
             </cmmn:condition>
                     </cmmn:manualActivationRule>
                 </cmmn:defaultControl>
             </cmmn:humanTask>
-            <cmmn:milestone id="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d"/>
+            <cmmn:milestone id="PID_Milestone"/>
         </cmmn:casePlanModel>
-  </cmmn:case>
-    
-    
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Page 1" id="P_b70a29d0-52f0-4f65-a1d1-47130791b832" sharedStyle="_1a32bab8-2d23-4e80-a673-46a04b51c6e1">
+            <cmmndi:Size height="500.0" width="661.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="_b70a29d0-52f0-4f65-a1d1-47130791b832" id="_1faea2f8-f56a-4c53-b297-c4adaf1741be">
+                <dc:Bounds height="156.0" width="361.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_3ae68cf1-c6a1-4462-bb03-767fe139d1d3">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="Milestone" id="_b22fe9ba-513a-4a43-b658-1b4a75f5d8b6">
+                <dc:Bounds height="39.0" width="115.0" x="356.0" y="209.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65557_entry1" id="_d9405cbb-0469-4a86-9400-1ee1144d260b">
+                <dc:Bounds height="28.0" width="20.0" x="403.5" y="195.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" isStandardEventVisible="true" targetCMMNElementRef="N65557_entry1" id="_3dcb43c9-e5b5-416b-a264-d270df5e84e3">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="349.75" y="228.0"/>
+                <di:waypoint x="349.75" y="174.0"/>
+                <di:waypoint x="413.5" y="174.0"/>
+                <di:waypoint x="413.5" y="195.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_1a32bab8-2d23-4e80-a673-46a04b51c6e1"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsCompletedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsCompletedTest.cmmn
@@ -1,34 +1,62 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
     <cmmn:case id="MilestoneAssertIsCompletedTest">
-    <cmmn:casePlanModel autoComplete="true" id="_b70a29d0-52f0-4f65-a1d1-47130791b832">
-            <cmmn:planItem definitionRef="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d" entryCriteriaRefs="_cf6057cb-b409-4363-a177-92df6bbee2b7" id="Milestone">
-                
+        <cmmn:casePlanModel autoComplete="true" id="_b70a29d0-52f0-4f65-a1d1-47130791b832">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_Milestone" id="Milestone">
+                <cmmn:entryCriterion sentryRef="_cf6057cb-b409-4363-a177-92df6bbee2b7" id="N65557_entry1"/>
             </cmmn:planItem>
             <cmmn:sentry id="_cf6057cb-b409-4363-a177-92df6bbee2b7">
-                <cmmn:planItemOnPart id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" sourceRef="PI_TaskA">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8">
                     <cmmn:standardEvent>complete</cmmn:standardEvent>
                 </cmmn:planItemOnPart>
             </cmmn:sentry>
-            <cmmn:humanTask id="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" isBlocking="true">
+            <cmmn:humanTask isBlocking="true" id="PID_PI_TaskA">
                 <cmmn:defaultControl>
                     <cmmn:requiredRule id="_7a98952a-a040-49a8-b479-1df83da3309e">
                         <cmmn:condition id="bbe1c437-0e31-4941-b556-d9380905b775">
-              <cmmn:body>${true}</cmmn:body>
+              ${true}
             </cmmn:condition>
                     </cmmn:requiredRule>
                     <cmmn:manualActivationRule id="e0b48876-fe8d-442f-8bf1-467db41846fe">
                         <cmmn:condition id="d5d8fcd6-1356-4685-9ef2-a477eaa98fb2">
-              <cmmn:body>${false}</cmmn:body>
+              ${false}
             </cmmn:condition>
                     </cmmn:manualActivationRule>
                 </cmmn:defaultControl>
             </cmmn:humanTask>
-            <cmmn:milestone id="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d"/>
+            <cmmn:milestone id="PID_Milestone"/>
         </cmmn:casePlanModel>
-  </cmmn:case>
-    
-    
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Page 1" id="P_b70a29d0-52f0-4f65-a1d1-47130791b832" sharedStyle="_7ccf3219-99c5-473f-a741-8a4f902567a7">
+            <cmmndi:Size height="500.0" width="661.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="_b70a29d0-52f0-4f65-a1d1-47130791b832" id="_9bd2df9b-7601-407f-bd8c-6217d3739348">
+                <dc:Bounds height="156.0" width="361.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_02e22e60-bbf5-4e05-9053-6a1ba4c115fb">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="Milestone" id="_ac4f6949-01cd-4380-b206-4fee0134c54e">
+                <dc:Bounds height="39.0" width="115.0" x="356.0" y="209.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65557_entry1" id="_3b41b25c-aaf5-4028-b0d7-d9f9635f8844">
+                <dc:Bounds height="28.0" width="20.0" x="403.5" y="195.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" isStandardEventVisible="true" targetCMMNElementRef="N65557_entry1" id="_5a5fdc27-889e-4e33-9e33-5079543a43a2">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="351.75" y="228.0"/>
+                <di:waypoint x="351.75" y="176.0"/>
+                <di:waypoint x="413.5" y="176.0"/>
+                <di:waypoint x="413.5" y="195.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_7ccf3219-99c5-473f-a741-8a4f902567a7"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/MilestoneAssertIsTerminatedTest.cmmn
@@ -1,54 +1,98 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler" id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="_4062973c-a12e-4992-8631-18f0b1f7311b" name="Drawing 1" targetNamespace="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns="http://www.trisotech.com/cmmn/definitions/_4062973c-a12e-4992-8631-18f0b1f7311b" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
     <cmmn:case id="MilestoneAssertIsTerminatedTest">
         <cmmn:casePlanModel autoComplete="true" id="_b70a29d0-52f0-4f65-a1d1-47130791b832">
-            <cmmn:planItem definitionRef="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID__f522601b-00cb-49eb-a762-f30549b8cfa2" exitCriteriaRefs="_08a26e6b-1ed4-4157-9a2f-ca63f450b4f3"
-                           id="Stage">
-
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_Stage" id="Stage">
+                <cmmn:exitCriterion sentryRef="_08a26e6b-1ed4-4157-9a2f-ca63f450b4f3" id="N65557_exit1"/>
             </cmmn:planItem>
             <cmmn:sentry id="_08a26e6b-1ed4-4157-9a2f-ca63f450b4f3">
-                <cmmn:planItemOnPart id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" sourceRef="PI_TaskA">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8">
                     <cmmn:standardEvent>complete</cmmn:standardEvent>
                 </cmmn:planItemOnPart>
             </cmmn:sentry>
-            <cmmn:humanTask id="PID__1516678a-0fb0-4586-99b1-2b35336c67a3" isBlocking="true">
+            <cmmn:humanTask isBlocking="true" id="PID_PI_TaskA">
                 <cmmn:defaultControl>
                     <cmmn:requiredRule id="_73124fbd-074f-4ecd-9beb-59bd095bca1b">
                         <cmmn:condition id="_20b89f27-d461-48f7-a0c1-006999ad3eb9">
-                            <cmmn:body>${true}</cmmn:body>
+                            ${true}
                         </cmmn:condition>
                     </cmmn:requiredRule>
                     <cmmn:manualActivationRule id="_4e4b6c1b-a4af-4002-9c2e-345b0f145250">
                         <cmmn:condition id="_4821a975-64f8-4dce-b7b1-f717c1ccf5eb">
-                            <cmmn:body>${false}</cmmn:body>
+                            ${false}
                         </cmmn:condition>
                     </cmmn:manualActivationRule>
                 </cmmn:defaultControl>
             </cmmn:humanTask>
-            <cmmn:stage autoComplete="false" id="PID__f522601b-00cb-49eb-a762-f30549b8cfa2">
+            <cmmn:stage autoComplete="false" id="PID_Stage">
                 <cmmn:defaultControl>
-                    <cmmn:manualActivationRule>
-                        <cmmn:condition>
-                            <cmmn:body>${false}</cmmn:body>
+                    <cmmn:manualActivationRule id="abd53df8-1d5f-4c6b-a8e9-14105cd447ad">
+                        <cmmn:condition id="_5e49b00f-05c6-40c1-ad24-98a083f48752">
+                            ${false}
                         </cmmn:condition>
                     </cmmn:manualActivationRule>
                 </cmmn:defaultControl>
-                <cmmn:planItem definitionRef="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d" entryCriteriaRefs="_6b754114-55aa-4aff-85cb-4dd19b3c4592"
-                               id="Milestone">
-
+                <cmmn:planItem definitionRef="PID_Milestone" id="Milestone">
+                    <cmmn:entryCriterion sentryRef="_6b754114-55aa-4aff-85cb-4dd19b3c4592" id="N65621_entry1"/>
                 </cmmn:planItem>
-                <cmmn:planItem definitionRef="PID__6db44200-6527-4f4a-b2d3-e08cb5ce336a" id="PI_TaskB"/>
+                <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB"/>
                 <cmmn:sentry id="_6b754114-55aa-4aff-85cb-4dd19b3c4592">
-                    <cmmn:planItemOnPart id="_7f53412d-8ca9-43c3-aa79-19bf14b2e4d4" sourceRef="PI_TaskB">
+                    <cmmn:planItemOnPart sourceRef="PI_TaskB" id="_7f53412d-8ca9-43c3-aa79-19bf14b2e4d4">
                         <cmmn:standardEvent>complete</cmmn:standardEvent>
                     </cmmn:planItemOnPart>
                 </cmmn:sentry>
-                <cmmn:milestone id="PID__bc9919ad-5b07-4fb5-85fc-b3bb3bc4ff4d"/>
-                <cmmn:humanTask id="PID__6db44200-6527-4f4a-b2d3-e08cb5ce336a" isBlocking="true"/>
+                <cmmn:milestone id="PID_Milestone"/>
+                <cmmn:humanTask isBlocking="true" id="PID_PI_TaskB"/>
             </cmmn:stage>
         </cmmn:casePlanModel>
     </cmmn:case>
-
-
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Page 1" id="P_b70a29d0-52f0-4f65-a1d1-47130791b832" sharedStyle="_14442156-0e41-4413-866f-26aa49bd2fbc">
+            <cmmndi:Size height="576.0" width="947.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="_b70a29d0-52f0-4f65-a1d1-47130791b832" id="_a402bf3d-9ec4-4646-856c-d00815d544d3">
+                <dc:Bounds height="276.0" width="647.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_99fedcf0-94b0-4d5e-8a88-9bab53b09b6e">
+                <dc:Bounds height="76.0" width="96.0" x="661.0" y="250.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="Stage" isCollapsed="false" id="_72bfd7c9-8ea9-4ca7-b148-3de5961fd106">
+                <dc:Bounds height="196.0" width="401.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="Milestone" id="_09e3b5c0-96d3-4c31-a33a-364d160d2407">
+                <dc:Bounds height="39.0" width="115.0" x="416.0" y="269.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_f27b05f6-5ebb-4d5b-acf8-323cc7240286">
+                <dc:Bounds height="76.0" width="96.0" x="250.0" y="250.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65621_entry1" id="_c38a18b9-f8a3-42d0-9006-cb9d27915404">
+                <dc:Bounds height="28.0" width="20.0" x="463.5" y="255.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65557_exit1" id="_4427c67a-192a-41d8-b96b-6e0b72845c3d">
+                <dc:Bounds height="28.0" width="20.0" x="581.0" y="274.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_7f53412d-8ca9-43c3-aa79-19bf14b2e4d4" isStandardEventVisible="true" targetCMMNElementRef="N65621_entry1" id="_056060df-7894-4f24-9539-864370c619ed">
+                <di:waypoint x="346.0" y="288.0"/>
+                <di:waypoint x="409.75" y="288.0"/>
+                <di:waypoint x="409.75" y="234.0"/>
+                <di:waypoint x="473.5" y="234.0"/>
+                <di:waypoint x="473.5" y="255.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+            <cmmndi:CMMNEdge cmmnElementRef="_db4acf8d-40c1-4e1f-b9c9-ad3510e605f8" isStandardEventVisible="true" targetCMMNElementRef="N65557_exit1" id="_a74fff21-558b-4707-b52c-d8b6668f2a14">
+                <di:waypoint x="601.0" y="288.0"/>
+                <di:waypoint x="661.0" y="288.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_14442156-0e41-4413-866f-26aa49bd2fbc"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssert-variables.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssert-variables.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssert-variables" name="ProcessTaskAssert-variables Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssert-variables">
-  <cmmn:case id="Case_ProcessTaskAssert-variables" name="ProcessTaskAssert-variables Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssert-variables" name="ProcessTaskAssert-variables Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssert-variables" name="ProcessTaskAssert-variables Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssert-variables" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssert-variables" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssert-variables Test" id="Case_ProcessTaskAssert-variables">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssert-variables Test" id="CPM_ProcessTaskAssert-variables">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssert-variables Test" id="PCPM_ProcessTaskAssert-variables" sharedStyle="_7977e8d2-91de-44e1-aa93-f03306a6af6e">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssert-variables" id="_ac859123-a947-4957-801e-16f7f3992780">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_8c5123de-8709-4c24-b2e8-440bdf7182f5">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_7977e8d2-91de-44e1-aa93-f03306a6af6e"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsActiveTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsActiveTest.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsActiveTest" name="ProcessTaskAssertIsActive Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsActiveTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsActiveTest" name="ProcessTaskAssertIsActive Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsActiveTest" name="ProcessTaskAssertIsActive Test">
-      <cmmn:planItem definitionRef="PT_TaskA" id="PI_TaskA"/>
-      <cmmn:processTask description="" id="PT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsActiveTest" name="ProcessTaskAssertIsActive Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsActiveTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsActiveTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertIsActive Test" id="Case_ProcessTaskAssertIsActiveTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsActive Test" id="CPM_ProcessTaskAssertIsActiveTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsActive Test" id="PCPM_ProcessTaskAssertIsActiveTest" sharedStyle="eb912fdd-6ff5-4017-b9fa-3c8916a4dc5d">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsActiveTest" id="_d3a3cc06-15a2-4274-aae3-546ccb0ccb7a">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_b0dbf3c8-25c8-4322-a8c9-66bf3c2f138f">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="eb912fdd-6ff5-4017-b9fa-3c8916a4dc5d"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsAvailableTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsAvailableTest.cmmn
@@ -1,52 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="ProcessTaskAssertIsAvailable Test" id="Case_ProcessTaskAssertIsAvailableTest">
-        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsAvailable Test" id="CPM_ProcessTaskAssertIsAvailableTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_HT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_4f247199-43dc-4ca7-853a-b22fe7593d48">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:processTask>
-            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsAvailable Test" id="PCPM_ProcessTaskAssertIsAvailableTest" sharedStyle="_4b0eb99e-3499-42ea-be5c-d85a372135a8">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsAvailableTest" id="_845c3a2d-6ef8-44bb-bc09-7c5d855e760e">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_9cbe9687-d608-41d8-9517-cdffb1d11f57">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_ec612de2-2f34-4a13-b2f8-38f9e0810b8b">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_8ba27f29-7481-4328-8b08-733cc2f13680">
-                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="_4f247199-43dc-4ca7-853a-b22fe7593d48" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_b71adc68-6c1d-4a89-8deb-5cbc1cfac7ea">
-                <di:waypoint x="286.0" y="228.0"/>
-                <di:waypoint x="346.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_4b0eb99e-3499-42ea-be5c-d85a372135a8"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test">
+    <cmmn:casePlanModel id="CPM_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:entryCriterion id="N65560_entry1" sentryRef="On_PI_HT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_A_Complete">
+        <cmmn:planItemOnPart id="_4f247199-43dc-4ca7-853a-b22fe7593d48" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:processTask id="PID_PI_TaskA" name="A" processRef="ProcessTaskAssert-calledProcess">
+        <cmmn:defaultControl>
+          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel">#{false}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:defaultControl>
+      </cmmn:processTask>
+      <cmmn:processTask id="PID_PI_TaskB" name="B" processRef="ProcessTaskAssert-calledProcess" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="_4b0eb99e-3499-42ea-be5c-d85a372135a8" id="PCPM_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_845c3a2d-6ef8-44bb-bc09-7c5d855e760e" cmmnElementRef="CPM_ProcessTaskAssertIsAvailableTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_9cbe9687-d608-41d8-9517-cdffb1d11f57" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_ec612de2-2f34-4a13-b2f8-38f9e0810b8b" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_8ba27f29-7481-4328-8b08-733cc2f13680" cmmnElementRef="N65560_entry1">
+        <dc:Bounds x="346" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_b71adc68-6c1d-4a89-8deb-5cbc1cfac7ea" cmmnElementRef="_4f247199-43dc-4ca7-853a-b22fe7593d48" targetCMMNElementRef="N65560_entry1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="286" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="346" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="_4b0eb99e-3499-42ea-be5c-d85a372135a8" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsAvailableTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsAvailableTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-      <cmmn:processTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsAvailableTest" name="ProcessTaskAssertIsAvailable Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsAvailableTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertIsAvailable Test" id="Case_ProcessTaskAssertIsAvailableTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsAvailable Test" id="CPM_ProcessTaskAssertIsAvailableTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_4f247199-43dc-4ca7-853a-b22fe7593d48">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsAvailable Test" id="PCPM_ProcessTaskAssertIsAvailableTest" sharedStyle="_4b0eb99e-3499-42ea-be5c-d85a372135a8">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsAvailableTest" id="_845c3a2d-6ef8-44bb-bc09-7c5d855e760e">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_9cbe9687-d608-41d8-9517-cdffb1d11f57">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_ec612de2-2f34-4a13-b2f8-38f9e0810b8b">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_8ba27f29-7481-4328-8b08-733cc2f13680">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_4f247199-43dc-4ca7-853a-b22fe7593d48" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_b71adc68-6c1d-4a89-8deb-5cbc1cfac7ea">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_4b0eb99e-3499-42ea-be5c-d85a372135a8"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsCompletedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsCompletedTest.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsCompletedTest" name="ProcessTaskAssertIsCompleted Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsCompletedTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsCompletedTest" name="ProcessTaskAssertIsCompleted Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsCompletedTest" name="ProcessTaskAssertIsCompleted Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsCompletedTest" name="ProcessTaskAssertIsCompleted Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsCompletedTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsCompletedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertIsCompleted Test" id="Case_ProcessTaskAssertIsCompletedTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsCompleted Test" id="CPM_ProcessTaskAssertIsCompletedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsCompleted Test" id="PCPM_ProcessTaskAssertIsCompletedTest" sharedStyle="ae9708dd-7c07-4d83-9ba2-8c03c6cd53d4">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsCompletedTest" id="_8ce01d08-5452-44fe-a222-343c99815ba4">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_2a6726fc-bf7b-4825-b726-b4bb7259c45f">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="ae9708dd-7c07-4d83-9ba2-8c03c6cd53d4"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsDisabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsDisabledTest.cmmn
@@ -1,12 +1,24 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertisDisabled Test" id="Case_ProcessTaskAssertIsDisabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertisDisabled Test" id="CPM_ProcessTaskAssertIsDisabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertisDisabled Test" id="PCPM_ProcessTaskAssertIsDisabledTest" sharedStyle="b83a2104-d5d8-40e4-a107-1738451318bc">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsDisabledTest" id="_74faacc9-742e-4bb7-a47e-f584980ce02c">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_dc1921df-01cc-4962-984c-96778ded7995">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b83a2104-d5d8-40e4-a107-1738451318bc"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsDisabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsDisabledTest.cmmn
@@ -1,24 +1,29 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="ProcessTaskAssertisDisabled Test" id="Case_ProcessTaskAssertIsDisabledTest">
-        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertisDisabled Test" id="CPM_ProcessTaskAssertIsDisabledTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="ProcessTaskAssertisDisabled Test" id="PCPM_ProcessTaskAssertIsDisabledTest" sharedStyle="b83a2104-d5d8-40e4-a107-1738451318bc">
-            <cmmndi:Size height="500.0" width="550.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsDisabledTest" id="_74faacc9-742e-4bb7-a47e-f584980ce02c">
-                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_dc1921df-01cc-4962-984c-96778ded7995">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b83a2104-d5d8-40e4-a107-1738451318bc"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsDisabledTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test">
+    <cmmn:casePlanModel id="CPM_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA">
+        <cmmn:itemControl id="PlanItemControl_1f8i90g">
+          <cmmn:manualActivationRule id="ManualActivationRule_13zh3fe">
+            <cmmn:condition id="Expression_1mciwgr">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:processTask id="PID_PI_TaskA" name="A" processRef="ProcessTaskAssert-calledProcess" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="b83a2104-d5d8-40e4-a107-1738451318bc" id="PCPM_ProcessTaskAssertIsDisabledTest" name="ProcessTaskAssertisDisabled Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="550" height="500" />
+      <cmmndi:CMMNShape id="_74faacc9-742e-4bb7-a47e-f584980ce02c" cmmnElementRef="CPM_ProcessTaskAssertIsDisabledTest">
+        <dc:Bounds x="150" y="150" width="250" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_dc1921df-01cc-4962-984c-96778ded7995" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="b83a2104-d5d8-40e4-a107-1738451318bc" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsEnabledTest.cmmn
@@ -1,52 +1,49 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="ProcessTaskAssertIsEnabled Test" id="Case_ProcessTaskAssertIsEnabledTest">
-        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsEnabled Test" id="CPM_ProcessTaskAssertIsEnabledTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_HT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="ab0d6438-86ce-4cd4-ad93-ece8d13790dc">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:processTask>
-            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsEnabled Test" id="PCPM_ProcessTaskAssertIsEnabledTest" sharedStyle="b03e288b-46d3-46e2-9655-59d8d1fe1424">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsEnabledTest" id="_c3ec2b2d-3fff-44e5-bef4-ea2fd2fd3630">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_08279c79-1398-40c2-845b-d9e7f042e701">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_9aa7c580-1cc4-48d7-bc7a-a2eb658ccdc1">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_2ca9ec2c-ab73-4356-8f26-11932fed59dd">
-                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="ab0d6438-86ce-4cd4-ad93-ece8d13790dc" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_818d8dbd-201e-41c9-bc2e-bd2504873573">
-                <di:waypoint x="286.0" y="228.0"/>
-                <di:waypoint x="346.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b03e288b-46d3-46e2-9655-59d8d1fe1424"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test">
+    <cmmn:casePlanModel id="CPM_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:itemControl id="PlanItemControl_074szo5">
+          <cmmn:manualActivationRule id="ManualActivationRule_18t2wq7">
+            <cmmn:condition id="Expression_00ucv7a">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:entryCriterion id="N65560_entry1" sentryRef="On_PI_HT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_A_Complete">
+        <cmmn:planItemOnPart id="ab0d6438-86ce-4cd4-ad93-ece8d13790dc" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:processTask id="PID_PI_TaskA" name="A" processRef="ProcessTaskAssert-calledProcess" />
+      <cmmn:processTask id="PID_PI_TaskB" name="B" processRef="ProcessTaskAssert-calledProcess" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="b03e288b-46d3-46e2-9655-59d8d1fe1424" id="PCPM_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_c3ec2b2d-3fff-44e5-bef4-ea2fd2fd3630" cmmnElementRef="CPM_ProcessTaskAssertIsEnabledTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_08279c79-1398-40c2-845b-d9e7f042e701" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_9aa7c580-1cc4-48d7-bc7a-a2eb658ccdc1" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_2ca9ec2c-ab73-4356-8f26-11932fed59dd" cmmnElementRef="N65560_entry1">
+        <dc:Bounds x="346" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_818d8dbd-201e-41c9-bc2e-bd2504873573" cmmnElementRef="ab0d6438-86ce-4cd4-ad93-ece8d13790dc" targetCMMNElementRef="N65560_entry1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="286" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="346" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="b03e288b-46d3-46e2-9655-59d8d1fe1424" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsEnabledTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsEnabledTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-      <cmmn:processTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsEnabledTest" name="ProcessTaskAssertIsEnabled Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsEnabledTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertIsEnabled Test" id="Case_ProcessTaskAssertIsEnabledTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsEnabled Test" id="CPM_ProcessTaskAssertIsEnabledTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="ab0d6438-86ce-4cd4-ad93-ece8d13790dc">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsEnabled Test" id="PCPM_ProcessTaskAssertIsEnabledTest" sharedStyle="b03e288b-46d3-46e2-9655-59d8d1fe1424">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsEnabledTest" id="_c3ec2b2d-3fff-44e5-bef4-ea2fd2fd3630">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_08279c79-1398-40c2-845b-d9e7f042e701">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_9aa7c580-1cc4-48d7-bc7a-a2eb658ccdc1">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_2ca9ec2c-ab73-4356-8f26-11932fed59dd">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="ab0d6438-86ce-4cd4-ad93-ece8d13790dc" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_818d8dbd-201e-41c9-bc2e-bd2504873573">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="b03e288b-46d3-46e2-9655-59d8d1fe1424"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsTerminatedTest.cmmn
@@ -1,52 +1,51 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="ProcessTaskAssertIsTerminated Test" id="Case_ProcessTaskAssertIsTerminatedTest">
-        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsTerminated Test" id="CPM_ProcessTaskAssertIsTerminatedTest">
-            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
-                <cmmn:exitCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_exit1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_HT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_2c44a60a-f150-4214-a569-842e2a6ed70c">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
-                <cmmn:defaultControl>
-                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
-                    </cmmn:manualActivationRule>
-                </cmmn:defaultControl>
-            </cmmn:processTask>
-            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsTerminated Test" id="PCPM_ProcessTaskAssertIsTerminatedTest" sharedStyle="afe4fd12-829c-4715-839b-676b3ebfc987">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsTerminatedTest" id="_63636d21-9beb-4acc-908b-bcb9954c1418">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_41557a9c-037a-4d54-a447-9cf205c16ef7">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_a814f43e-e80f-4b6e-8b77-785e9d802df1">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_exit1" id="_2abd8dee-57d1-4b7a-a4c4-0252efadeac7">
-                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="_2c44a60a-f150-4214-a569-842e2a6ed70c" isStandardEventVisible="true" targetCMMNElementRef="N65560_exit1" id="_00258802-7b71-4fcf-b41b-812f8baccc41">
-                <di:waypoint x="296.0" y="228.0"/>
-                <di:waypoint x="356.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="afe4fd12-829c-4715-839b-676b3ebfc987"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test">
+    <cmmn:casePlanModel id="CPM_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test" autoComplete="false">
+      <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA" />
+      <cmmn:planItem id="PI_TaskB" definitionRef="PID_PI_TaskB">
+        <cmmn:itemControl id="PlanItemControl_1gpe3z3">
+          <cmmn:manualActivationRule id="ManualActivationRule_0rsbm9y">
+            <cmmn:condition id="Expression_0do67pl">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:exitCriterion id="N65560_exit1" sentryRef="On_PI_HT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_A_Complete">
+        <cmmn:planItemOnPart id="_2c44a60a-f150-4214-a569-842e2a6ed70c" sourceRef="PI_TaskA">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:processTask id="PID_PI_TaskA" name="A" processRef="ProcessTaskAssert-calledProcess">
+        <cmmn:defaultControl />
+      </cmmn:processTask>
+      <cmmn:processTask id="PID_PI_TaskB" name="B" processRef="ProcessTaskAssert-calledProcess" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="afe4fd12-829c-4715-839b-676b3ebfc987" id="PCPM_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_63636d21-9beb-4acc-908b-bcb9954c1418" cmmnElementRef="CPM_ProcessTaskAssertIsTerminatedTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_41557a9c-037a-4d54-a447-9cf205c16ef7" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_a814f43e-e80f-4b6e-8b77-785e9d802df1" cmmnElementRef="PI_TaskB">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_2abd8dee-57d1-4b7a-a4c4-0252efadeac7" cmmnElementRef="N65560_exit1">
+        <dc:Bounds x="276" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_00258802-7b71-4fcf-b41b-812f8baccc41" cmmnElementRef="_2c44a60a-f150-4214-a569-842e2a6ed70c" targetCMMNElementRef="N65560_exit1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="296" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="356" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="afe4fd12-829c-4715-839b-676b3ebfc987" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsTerminatedTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/ProcessTaskAssertIsTerminatedTest.cmmn
@@ -1,25 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest">
-  <cmmn:case id="Case_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:planItem definitionRef="HT_TaskB" exitCriteriaRefs="On_PI_HT_A_Complete" id="PI_TaskB"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_TaskA">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:processTask description="" id="HT_TaskA" isBlocking="true" name="A" processRef="ProcessTaskAssert-calledProcess">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:processTask>
-      <cmmn:processTask description="" id="HT_TaskB" isBlocking="true" name="B">
-      </cmmn:processTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_ProcessTaskAssertIsTerminatedTest" name="ProcessTaskAssertIsTerminated Test" targetNamespace="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" xmlns="http://www.trisotech.com/cmmn/definitions/ProcessTaskAssertIsTerminatedTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="ProcessTaskAssertIsTerminated Test" id="Case_ProcessTaskAssertIsTerminatedTest">
+        <cmmn:casePlanModel autoComplete="false" name="ProcessTaskAssertIsTerminated Test" id="CPM_ProcessTaskAssertIsTerminatedTest">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:planItem definitionRef="PID_PI_TaskB" id="PI_TaskB">
+                <cmmn:exitCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_exit1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_TaskA" id="_2c44a60a-f150-4214-a569-842e2a6ed70c">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:processTask processRef="ProcessTaskAssert-calledProcess" isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:processTask>
+            <cmmn:processTask isBlocking="true" name="B" id="PID_PI_TaskB"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="ProcessTaskAssertIsTerminated Test" id="PCPM_ProcessTaskAssertIsTerminatedTest" sharedStyle="afe4fd12-829c-4715-839b-676b3ebfc987">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_ProcessTaskAssertIsTerminatedTest" id="_63636d21-9beb-4acc-908b-bcb9954c1418">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_41557a9c-037a-4d54-a447-9cf205c16ef7">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskB" id="_a814f43e-e80f-4b6e-8b77-785e9d802df1">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_exit1" id="_2abd8dee-57d1-4b7a-a4c4-0252efadeac7">
+                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_2c44a60a-f150-4214-a569-842e2a6ed70c" isStandardEventVisible="true" targetCMMNElementRef="N65560_exit1" id="_00258802-7b71-4fcf-b41b-812f8baccc41">
+                <di:waypoint x="296.0" y="228.0"/>
+                <di:waypoint x="356.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="afe4fd12-829c-4715-839b-676b3ebfc987"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageTest.cmmn
@@ -1,31 +1,42 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageTests" name="Stage Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/StageTests" xmlns="http://www.trisotech.com/cmmn/definitions/StageTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="Stage Tests" id="Case_StageTests">
-        <cmmn:casePlanModel autoComplete="false" name="Stage Tests" id="CPM_StageTests">
-            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS"/>
-            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS">
-                <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
-                <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA"/>
-            </cmmn:stage>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="Stage Tests" id="PCPM_StageTests" sharedStyle="c8e4a14d-22df-4a40-ad4a-7b0152c640ae">
-            <cmmndi:Size height="576.0" width="596.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_StageTests" id="_22a5e301-5866-40e2-9978-6d25cccc2ea7">
-                <dc:Bounds height="276.0" width="296.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="false" id="_421692d5-8162-4a8a-a941-441ac83a3ab6">
-                <dc:Bounds height="196.0" width="216.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_ad068218-30c4-46cc-a281-e025b1e5bb91">
-                <dc:Bounds height="76.0" width="96.0" x="250.0" y="250.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="c8e4a14d-22df-4a40-ad4a-7b0152c640ae"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/StageTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_StageTests" name="Stage Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/StageTests" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_StageTests" name="Stage Tests">
+    <cmmn:casePlanModel id="CPM_StageTests" name="Stage Tests" autoComplete="false">
+      <cmmn:planItem id="PI_StageS" definitionRef="PID_PI_StageS">
+        <cmmn:itemControl id="PlanItemControl_0u1k7js">
+          <cmmn:manualActivationRule id="ManualActivationRule_1fecwzc">
+            <cmmn:condition id="Expression_161fejs">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:stage id="PID_PI_StageS" name="S" autoComplete="false">
+        <cmmn:planItem id="PI_TaskA" definitionRef="PID_PI_TaskA">
+          <cmmn:itemControl id="PlanItemControl_0k5w9tq">
+            <cmmn:manualActivationRule id="ManualActivationRule_0yqw2ln">
+              <cmmn:condition id="Expression_1278cdx">${true}</cmmn:condition>
+            </cmmn:manualActivationRule>
+          </cmmn:itemControl>
+        </cmmn:planItem>
+        <cmmn:humanTask id="PID_PI_TaskA" name="A" />
+      </cmmn:stage>
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="c8e4a14d-22df-4a40-ad4a-7b0152c640ae" id="PCPM_StageTests" name="Stage Tests">
+      <cmmndi:Size xsi:type="dc:Dimension" width="596" height="576" />
+      <cmmndi:CMMNShape id="_22a5e301-5866-40e2-9978-6d25cccc2ea7" cmmnElementRef="CPM_StageTests">
+        <dc:Bounds x="150" y="150" width="296" height="276" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_421692d5-8162-4a8a-a941-441ac83a3ab6" cmmnElementRef="PI_StageS" isCollapsed="false">
+        <dc:Bounds x="190" y="190" width="216" height="196" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_ad068218-30c4-46cc-a281-e025b1e5bb91" cmmnElementRef="PI_TaskA">
+        <dc:Bounds x="250" y="250" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="c8e4a14d-22df-4a40-ad4a-7b0152c640ae" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageTest.cmmn
@@ -1,15 +1,31 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_StageTests" name="Stage Tests"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/StageTests">
-  <cmmn:case id="Case_StageTests" name="Stage Tests">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_StageTests" name="Stage Tests">
-      <cmmn:planItem definitionRef="S_StageS" id="PI_StageS"/>
-      <cmmn:stage id="S_StageS" autoComplete="false" name="S">
-        <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-        <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        </cmmn:humanTask>
-      </cmmn:stage>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageTests" name="Stage Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/StageTests" xmlns="http://www.trisotech.com/cmmn/definitions/StageTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Stage Tests" id="Case_StageTests">
+        <cmmn:casePlanModel autoComplete="false" name="Stage Tests" id="CPM_StageTests">
+            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS"/>
+            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS">
+                <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+                <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA"/>
+            </cmmn:stage>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Stage Tests" id="PCPM_StageTests" sharedStyle="c8e4a14d-22df-4a40-ad4a-7b0152c640ae">
+            <cmmndi:Size height="576.0" width="596.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_StageTests" id="_22a5e301-5866-40e2-9978-6d25cccc2ea7">
+                <dc:Bounds height="276.0" width="296.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="false" id="_421692d5-8162-4a8a-a941-441ac83a3ab6">
+                <dc:Bounds height="196.0" width="216.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_ad068218-30c4-46cc-a281-e025b1e5bb91">
+                <dc:Bounds height="76.0" width="96.0" x="250.0" y="250.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="c8e4a14d-22df-4a40-ad4a-7b0152c640ae"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTest.cmmn
@@ -1,21 +1,46 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_StageWithSentryTests" name="Stage with Sentry Tests"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests">
-  <cmmn:case id="Case_StageWithSentryTests" name="Stage with Sentry Tests">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_StageWithSentryTests" name="Stage with Sentry Tests">
-      <cmmn:planItem definitionRef="HT_A" id="PI_HT_A"/>
-      <cmmn:planItem definitionRef="S_StageS" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_StageS"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_HT_A">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_A" isBlocking="true" name="A">
-      </cmmn:humanTask>
-      <cmmn:stage id="S_StageS" autoComplete="false" name="S">
-      </cmmn:stage>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageWithSentryTests" name="Stage with Sentry Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Stage with Sentry Tests" id="Case_StageWithSentryTests">
+        <cmmn:casePlanModel autoComplete="false" name="Stage with Sentry Tests" id="CPM_StageWithSentryTests">
+            <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A"/>
+            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_HT_A" id="_5e619215-c580-4fc2-bf50-e88c47209f9a">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
+            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Stage with Sentry Tests" id="PCPM_StageWithSentryTests" sharedStyle="fe32bf0b-0b5c-4752-b720-e901e167b531">
+            <cmmndi:Size height="500.0" width="680.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_StageWithSentryTests" id="_8fcd0ab1-13e3-4736-9571-c9cf5f06830e">
+                <dc:Bounds height="156.0" width="380.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_46fbda95-ebae-444b-a7ea-6d59cff14631">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="true" id="_e2f0bbcd-2126-4ecf-b7b0-62d495912785">
+                <dc:Bounds height="76.0" width="134.0" x="356.0" y="192.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_148e0242-d59b-4e06-a499-6fd858de0d05">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_5e619215-c580-4fc2-bf50-e88c47209f9a" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_c8b6dbfb-377a-49cb-84c8-7586200bf4fb">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="fe32bf0b-0b5c-4752-b720-e901e167b531"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
 

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTest.cmmn
@@ -1,46 +1,55 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageWithSentryTests" name="Stage with Sentry Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="Stage with Sentry Tests" id="Case_StageWithSentryTests">
-        <cmmn:casePlanModel autoComplete="false" name="Stage with Sentry Tests" id="CPM_StageWithSentryTests">
-            <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A"/>
-            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS">
-                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
-            </cmmn:planItem>
-            <cmmn:sentry id="On_PI_HT_A_Complete">
-                <cmmn:planItemOnPart sourceRef="PI_HT_A" id="_5e619215-c580-4fc2-bf50-e88c47209f9a">
-                    <cmmn:standardEvent>complete</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
-            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="Stage with Sentry Tests" id="PCPM_StageWithSentryTests" sharedStyle="fe32bf0b-0b5c-4752-b720-e901e167b531">
-            <cmmndi:Size height="500.0" width="680.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_StageWithSentryTests" id="_8fcd0ab1-13e3-4736-9571-c9cf5f06830e">
-                <dc:Bounds height="156.0" width="380.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_46fbda95-ebae-444b-a7ea-6d59cff14631">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="true" id="_e2f0bbcd-2126-4ecf-b7b0-62d495912785">
-                <dc:Bounds height="76.0" width="134.0" x="356.0" y="192.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_148e0242-d59b-4e06-a499-6fd858de0d05">
-                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="_5e619215-c580-4fc2-bf50-e88c47209f9a" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_c8b6dbfb-377a-49cb-84c8-7586200bf4fb">
-                <di:waypoint x="286.0" y="228.0"/>
-                <di:waypoint x="346.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="fe32bf0b-0b5c-4752-b720-e901e167b531"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_StageWithSentryTests" name="Stage with Sentry Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryTests" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_StageWithSentryTests" name="Stage with Sentry Tests">
+    <cmmn:casePlanModel id="CPM_StageWithSentryTests" name="Stage with Sentry Tests" autoComplete="false">
+      <cmmn:planItem id="PI_HT_A" definitionRef="PID_PI_HT_A">
+        <cmmn:itemControl id="PlanItemControl_1v0x4nu">
+          <cmmn:manualActivationRule id="ManualActivationRule_06z2dsq">
+            <cmmn:condition id="Expression_0e7cksy">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:planItem id="PI_StageS" definitionRef="PID_PI_StageS">
+        <cmmn:itemControl id="PlanItemControl_06fiuzk">
+          <cmmn:manualActivationRule id="ManualActivationRule_0ch4eek">
+            <cmmn:condition id="Expression_0ucw6l0">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:entryCriterion id="N65560_entry1" sentryRef="On_PI_HT_A_Complete" />
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_A_Complete">
+        <cmmn:planItemOnPart id="_5e619215-c580-4fc2-bf50-e88c47209f9a" sourceRef="PI_HT_A">        <cmmn:standardEvent>complete</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:humanTask id="PID_PI_HT_A" name="A" />
+      <cmmn:stage id="PID_PI_StageS" name="S" autoComplete="false" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="fe32bf0b-0b5c-4752-b720-e901e167b531" id="PCPM_StageWithSentryTests" name="Stage with Sentry Tests">
+      <cmmndi:Size xsi:type="dc:Dimension" width="680" height="500" />
+      <cmmndi:CMMNShape id="_8fcd0ab1-13e3-4736-9571-c9cf5f06830e" cmmnElementRef="CPM_StageWithSentryTests">
+        <dc:Bounds x="150" y="150" width="380" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_46fbda95-ebae-444b-a7ea-6d59cff14631" cmmnElementRef="PI_HT_A">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_e2f0bbcd-2126-4ecf-b7b0-62d495912785" cmmnElementRef="PI_StageS" isCollapsed="true">
+        <dc:Bounds x="356" y="192" width="134" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_148e0242-d59b-4e06-a499-6fd858de0d05" cmmnElementRef="N65560_entry1">
+        <dc:Bounds x="346" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_c8b6dbfb-377a-49cb-84c8-7586200bf4fb" cmmnElementRef="_5e619215-c580-4fc2-bf50-e88c47209f9a" targetCMMNElementRef="N65560_entry1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="286" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="346" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="fe32bf0b-0b5c-4752-b720-e901e167b531" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTestExitCriteria.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTestExitCriteria.cmmn
@@ -1,24 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest">
-  <cmmn:case id="Case_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria">
-      <cmmn:planItem definitionRef="S_StageS" id="PI_StageS" exitCriteriaRefs="On_PI_HT_B_ManualStart"/>
-      <cmmn:planItem definitionRef="HT_B" id="PI_HT_B"/>
-      <cmmn:sentry id="On_PI_HT_B_ManualStart">
-        <cmmn:planItemOnPart sourceRef="PI_HT_B">
-          <cmmn:standardEvent>manualStart</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:stage id="S_StageS" autoComplete="false" name="S">
-        <cmmn:planItem definitionRef="HT_A" id="PI_HT_A"/>
-        <cmmn:humanTask description="" id="HT_A" isBlocking="true" name="A">
-        </cmmn:humanTask>
-      </cmmn:stage>
-      <cmmn:humanTask description="" id="HT_B" isBlocking="true" name="B">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Stage with Sentry Tests and Exit Criteria" id="Case_StageWithSentryExitCriteriaTest">
+        <cmmn:casePlanModel autoComplete="false" name="Stage with Sentry Tests and Exit Criteria" id="CPM_StageWithSentryExitCriteriaTest">
+            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS">
+                <cmmn:exitCriterion sentryRef="On_PI_HT_B_ManualStart" id="N65556_exit1"/>
+            </cmmn:planItem>
+            <cmmn:planItem definitionRef="PID_PI_HT_B" id="PI_HT_B"/>
+            <cmmn:sentry id="On_PI_HT_B_ManualStart">
+                <cmmn:planItemOnPart sourceRef="PI_HT_B" id="b254176d-d8e3-4542-bdb0-8108bf73188a">
+                    <cmmn:standardEvent>manualStart</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS">
+                <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A"/>
+                <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
+            </cmmn:stage>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_HT_B"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Stage with Sentry Tests and Exit Criteria" id="PCPM_StageWithSentryExitCriteriaTest" sharedStyle="afb871cd-d2ae-4dd7-8398-d3114fa72884">
+            <cmmndi:Size height="576.0" width="762.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_StageWithSentryExitCriteriaTest" id="_ce0acc5f-f743-4d3e-9a4e-8086dc832903">
+                <dc:Bounds height="276.0" width="462.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="false" id="_d90d0986-d2cd-405f-bc45-810d531b59f2">
+                <dc:Bounds height="196.0" width="216.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_86c6994f-a4ef-4dc3-9779-a69e6bc64c8d">
+                <dc:Bounds height="76.0" width="96.0" x="250.0" y="250.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_B" id="_3cbf7d9a-7413-4bfa-ba03-60bade1c4149">
+                <dc:Bounds height="76.0" width="96.0" x="476.0" y="250.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65556_exit1" id="_7385d524-6a2a-46ce-a964-50166972972b">
+                <dc:Bounds height="28.0" width="20.0" x="396.0" y="274.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="b254176d-d8e3-4542-bdb0-8108bf73188a" isStandardEventVisible="true" targetCMMNElementRef="N65556_exit1" id="_e1fcba51-47ac-4c06-9eec-bf7888c524bc">
+                <di:waypoint x="416.0" y="288.0"/>
+                <di:waypoint x="476.0" y="288.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="afb871cd-d2ae-4dd7-8398-d3114fa72884"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
 

--- a/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTestExitCriteria.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/StageWithSentryTestExitCriteria.cmmn
@@ -1,53 +1,68 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="Stage with Sentry Tests and Exit Criteria" id="Case_StageWithSentryExitCriteriaTest">
-        <cmmn:casePlanModel autoComplete="false" name="Stage with Sentry Tests and Exit Criteria" id="CPM_StageWithSentryExitCriteriaTest">
-            <cmmn:planItem definitionRef="PID_PI_StageS" id="PI_StageS">
-                <cmmn:exitCriterion sentryRef="On_PI_HT_B_ManualStart" id="N65556_exit1"/>
-            </cmmn:planItem>
-            <cmmn:planItem definitionRef="PID_PI_HT_B" id="PI_HT_B"/>
-            <cmmn:sentry id="On_PI_HT_B_ManualStart">
-                <cmmn:planItemOnPart sourceRef="PI_HT_B" id="b254176d-d8e3-4542-bdb0-8108bf73188a">
-                    <cmmn:standardEvent>manualStart</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:stage autoComplete="false" name="S" id="PID_PI_StageS">
-                <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A"/>
-                <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
-            </cmmn:stage>
-            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_HT_B"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="Stage with Sentry Tests and Exit Criteria" id="PCPM_StageWithSentryExitCriteriaTest" sharedStyle="afb871cd-d2ae-4dd7-8398-d3114fa72884">
-            <cmmndi:Size height="576.0" width="762.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_StageWithSentryExitCriteriaTest" id="_ce0acc5f-f743-4d3e-9a4e-8086dc832903">
-                <dc:Bounds height="276.0" width="462.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_StageS" isCollapsed="false" id="_d90d0986-d2cd-405f-bc45-810d531b59f2">
-                <dc:Bounds height="196.0" width="216.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_86c6994f-a4ef-4dc3-9779-a69e6bc64c8d">
-                <dc:Bounds height="76.0" width="96.0" x="250.0" y="250.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_HT_B" id="_3cbf7d9a-7413-4bfa-ba03-60bade1c4149">
-                <dc:Bounds height="76.0" width="96.0" x="476.0" y="250.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65556_exit1" id="_7385d524-6a2a-46ce-a964-50166972972b">
-                <dc:Bounds height="28.0" width="20.0" x="396.0" y="274.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="b254176d-d8e3-4542-bdb0-8108bf73188a" isStandardEventVisible="true" targetCMMNElementRef="N65556_exit1" id="_e1fcba51-47ac-4c06-9eec-bf7888c524bc">
-                <di:waypoint x="416.0" y="288.0"/>
-                <di:waypoint x="476.0" y="288.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="afb871cd-d2ae-4dd7-8398-d3114fa72884"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_StageWithSentryExitCriteriaTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria">
+    <cmmn:casePlanModel id="CPM_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria" autoComplete="false">
+      <cmmn:planItem id="PI_StageS" definitionRef="PID_PI_StageS">
+        <cmmn:itemControl id="PlanItemControl_10d87hs">
+          <cmmn:manualActivationRule id="ManualActivationRule_1j6k683">
+            <cmmn:condition id="Expression_1o03cs5">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:exitCriterion id="N65556_exit1" sentryRef="On_PI_HT_B_ManualStart" />
+      </cmmn:planItem>
+      <cmmn:planItem id="PI_HT_B" definitionRef="PID_PI_HT_B">
+        <cmmn:itemControl id="PlanItemControl_01rxe5o">
+          <cmmn:manualActivationRule id="ManualActivationRule_0sx6dma">
+            <cmmn:condition id="Expression_0ewq9lc">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_B_ManualStart">
+        <cmmn:planItemOnPart id="b254176d-d8e3-4542-bdb0-8108bf73188a" sourceRef="PI_HT_B">        <cmmn:standardEvent>manualStart</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:stage id="PID_PI_StageS" name="S" autoComplete="false">
+        <cmmn:planItem id="PI_HT_A" definitionRef="PID_PI_HT_A">
+          <cmmn:itemControl id="PlanItemControl_0sywbtr">
+            <cmmn:manualActivationRule id="ManualActivationRule_0krdhkm">
+              <cmmn:condition id="Expression_0zzaes5">${true}</cmmn:condition>
+            </cmmn:manualActivationRule>
+          </cmmn:itemControl>
+        </cmmn:planItem>
+        <cmmn:humanTask id="PID_PI_HT_A" name="A" />
+      </cmmn:stage>
+      <cmmn:humanTask id="PID_PI_HT_B" name="B" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="afb871cd-d2ae-4dd7-8398-d3114fa72884" id="PCPM_StageWithSentryExitCriteriaTest" name="Stage with Sentry Tests and Exit Criteria">
+      <cmmndi:Size xsi:type="dc:Dimension" width="762" height="576" />
+      <cmmndi:CMMNShape id="_ce0acc5f-f743-4d3e-9a4e-8086dc832903" cmmnElementRef="CPM_StageWithSentryExitCriteriaTest">
+        <dc:Bounds x="150" y="150" width="462" height="276" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_d90d0986-d2cd-405f-bc45-810d531b59f2" cmmnElementRef="PI_StageS" isCollapsed="false">
+        <dc:Bounds x="190" y="190" width="216" height="196" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_86c6994f-a4ef-4dc3-9779-a69e6bc64c8d" cmmnElementRef="PI_HT_A">
+        <dc:Bounds x="250" y="250" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_3cbf7d9a-7413-4bfa-ba03-60bade1c4149" cmmnElementRef="PI_HT_B">
+        <dc:Bounds x="476" y="250" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_7385d524-6a2a-46ce-a964-50166972972b" cmmnElementRef="N65556_exit1">
+        <dc:Bounds x="396" y="274" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_e1fcba51-47ac-4c06-9eec-bf7888c524bc" cmmnElementRef="b254176d-d8e3-4542-bdb0-8108bf73188a" targetCMMNElementRef="N65556_exit1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="416" y="288" />
+        <di:waypoint xsi:type="dc:Point" x="476" y="288" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="afb871cd-d2ae-4dd7-8398-d3114fa72884" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/TaskTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/TaskTest.cmmn
@@ -1,17 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_TaskTests" name="Task Tests"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/TaskTests">
-  <cmmn:case id="Case_TaskTests" name="Task Tests">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_TaskTests" name="Task Tests">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{false}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_TaskTests" name="Task Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/TaskTests" xmlns="http://www.trisotech.com/cmmn/definitions/TaskTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Task Tests" id="Case_TaskTests">
+        <cmmn:casePlanModel autoComplete="false" name="Task Tests" id="CPM_TaskTests">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{false}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Task Tests" id="PCPM_TaskTests" sharedStyle="_41f4d2ae-8821-4b41-938a-7b331e0b2e01">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_TaskTests" id="_34ab32d7-b6e2-4f36-bb5c-1f525b59848c">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_c7889afd-71b2-45a8-81cf-d926d4f03bb6">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_41f4d2ae-8821-4b41-938a-7b331e0b2e01"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/TaskWithManualActivationTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/TaskWithManualActivationTest.cmmn
@@ -1,20 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_TaskTests" name="Task Tests"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/TaskTests">
-  <cmmn:case id="Case_TaskTests" name="Task Tests">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_TaskTests" name="Task Tests">
-      <cmmn:planItem definitionRef="HT_TaskA" id="PI_TaskA"/>
-      <cmmn:humanTask description="" id="HT_TaskA" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <!-- we could just drop this rule declaration, because according to the CMMN spec,
-           if no manualActivationRule is specified, then the default is true.
-           But for sake of clarity we made this explicit. -->
-          <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
-            <cmmn:condition id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df" language="juel"><cmmn:body>#{true}</cmmn:body></cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_TaskTests" name="Task Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/TaskTests" xmlns="http://www.trisotech.com/cmmn/definitions/TaskTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Task Tests" id="Case_TaskTests">
+        <cmmn:casePlanModel autoComplete="false" name="Task Tests" id="CPM_TaskTests">
+            <cmmn:planItem definitionRef="PID_PI_TaskA" id="PI_TaskA"/>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_TaskA">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="_c814f81f-04ff-4100-bb88-63b1acc5a920">
+                        <cmmn:condition language="juel" id="f3953a0a-12ef-46f5-95ec-a0f60e0f45df">#{true}</cmmn:condition>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Task Tests" id="PCPM_TaskTests" sharedStyle="_2de183cb-b429-4133-a303-889ef8047504">
+            <cmmndi:Size height="500.0" width="550.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_TaskTests" id="_4514d086-38e1-4610-b5e1-07f591128734">
+                <dc:Bounds height="156.0" width="250.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_TaskA" id="_ae67e705-570d-4566-8c8e-a012961ee9df">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_2de183cb-b429-4133-a303-889ef8047504"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
+

--- a/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTest.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTest.cmmn
@@ -1,35 +1,62 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_TaskWithSentryTests" name="Task with Sentry Tests"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryTests">
-  <cmmn:case id="Case_TaskWithSentryTests" name="Task with Sentry Tests">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_TaskWithSentryTests" name="Task with Sentry Tests">
-      <cmmn:planItem definitionRef="HT_A" id="PI_HT_A"/>
-      <cmmn:planItem definitionRef="HT_B" entryCriteriaRefs="On_PI_HT_A_Complete" id="PI_HT_B"/>
-      <cmmn:sentry id="On_PI_HT_A_Complete">
-        <cmmn:planItemOnPart sourceRef="PI_HT_A">
-          <cmmn:standardEvent>complete</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_A" isBlocking="true" name="A">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="MAR_HT_A">
-            <cmmn:condition id="Cond_MAR_HT_A" language="juel">
-              <cmmn:body>#{false}</cmmn:body>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_TaskWithSentryTests" name="Task with Sentry Tests" targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryTests" xmlns="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryTests" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Task with Sentry Tests" id="Case_TaskWithSentryTests">
+        <cmmn:casePlanModel autoComplete="false" name="Task with Sentry Tests" id="CPM_TaskWithSentryTests">
+            <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A"/>
+            <cmmn:planItem definitionRef="PID_PI_HT_B" id="PI_HT_B">
+                <cmmn:entryCriterion sentryRef="On_PI_HT_A_Complete" id="N65560_entry1"/>
+            </cmmn:planItem>
+            <cmmn:sentry id="On_PI_HT_A_Complete">
+                <cmmn:planItemOnPart sourceRef="PI_HT_A" id="_40ff4dd3-f136-419d-834d-97c4bc1430e2">
+                    <cmmn:standardEvent>complete</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="MAR_HT_A">
+                        <cmmn:condition language="juel" id="Cond_MAR_HT_A">
+              #{false}
             </cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-      <cmmn:humanTask description="" id="HT_B" isBlocking="true" name="B">
-        <cmmn:defaultControl>
-          <cmmn:manualActivationRule id="MAR_HT_B">
-            <cmmn:condition id="Cond_MAR_HT_B" language="juel">
-              <cmmn:body>#{false}</cmmn:body>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_HT_B">
+                <cmmn:defaultControl>
+                    <cmmn:manualActivationRule id="MAR_HT_B">
+                        <cmmn:condition language="juel" id="Cond_MAR_HT_B">
+              #{false}
             </cmmn:condition>
-          </cmmn:manualActivationRule>
-        </cmmn:defaultControl>
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+                    </cmmn:manualActivationRule>
+                </cmmn:defaultControl>
+            </cmmn:humanTask>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Task with Sentry Tests" id="PCPM_TaskWithSentryTests" sharedStyle="_406b1053-c1a2-494b-aeaa-2f6a881e3cce">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_TaskWithSentryTests" id="_cacbf32a-62b7-4a1a-9200-2295e8d5fbdf">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_b82c4ee7-1bb1-4d87-b4ed-c435d6507c53">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_B" id="_1865c3bf-adac-48f9-8c55-1e92ca2a0472">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65560_entry1" id="_ca9fd642-42ad-44b1-9969-981e34c3efd2">
+                <dc:Bounds height="28.0" width="20.0" x="346.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="_40ff4dd3-f136-419d-834d-97c4bc1430e2" isStandardEventVisible="true" targetCMMNElementRef="N65560_entry1" id="_0a5485bd-a9da-4c08-a0b8-9e573e535643">
+                <di:waypoint x="286.0" y="228.0"/>
+                <di:waypoint x="346.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="_406b1053-c1a2-494b-aeaa-2f6a881e3cce"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
 

--- a/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTestExitCriteria.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTestExitCriteria.cmmn
@@ -1,46 +1,55 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" xmlns="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
-    <cmmn:case name="Task with Sentry Tests and Exit Criteria" id="Case_TaskWithSentryExitCriteriaTest">
-        <cmmn:casePlanModel autoComplete="false" name="Task with Sentry Tests" id="CPM_TaskWithSentryExitCriteriaTest">
-            <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A">
-                <cmmn:exitCriterion sentryRef="On_PI_HT_B_ManualStart" id="N65556_exit1"/>
-            </cmmn:planItem>
-            <cmmn:planItem definitionRef="PID_PI_HT_B" id="PI_HT_B"/>
-            <cmmn:sentry id="On_PI_HT_B_ManualStart">
-                <cmmn:planItemOnPart sourceRef="PI_HT_B" id="f314d875-694b-40a1-a96c-d8c37084c0c4">
-                    <cmmn:standardEvent>manualStart</cmmn:standardEvent>
-                </cmmn:planItemOnPart>
-            </cmmn:sentry>
-            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
-            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_HT_B"/>
-        </cmmn:casePlanModel>
-    </cmmn:case>
-    <cmmndi:CMMNDI>
-        <cmmndi:CMMNDiagram name="Task with Sentry Tests" id="PCPM_TaskWithSentryExitCriteriaTest" sharedStyle="d4da590d-a61b-41d0-8f01-c62696eca972">
-            <cmmndi:Size height="500.0" width="642.0"/>
-            <cmmndi:CMMNShape cmmnElementRef="CPM_TaskWithSentryExitCriteriaTest" id="_f3ef863d-2098-4cb7-aa06-3068a4be1177">
-                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_d9e77d80-719a-4f69-a43d-514d50206cf1">
-                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="PI_HT_B" id="_e423c7d5-81f7-4317-98f7-0d40ebe4037d">
-                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNShape cmmnElementRef="N65556_exit1" id="_4255c1ed-934b-413a-9b8c-57ae37be0391">
-                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNShape>
-            <cmmndi:CMMNEdge cmmnElementRef="f314d875-694b-40a1-a96c-d8c37084c0c4" isStandardEventVisible="true" targetCMMNElementRef="N65556_exit1" id="_47fda588-082f-44f9-b7db-37a68a1a5f07">
-                <di:waypoint x="296.0" y="228.0"/>
-                <di:waypoint x="356.0" y="228.0"/>
-                <cmmndi:CMMNLabel/>
-            </cmmndi:CMMNEdge>
-        </cmmndi:CMMNDiagram>
-        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="d4da590d-a61b-41d0-8f01-c62696eca972"/>
-    </cmmndi:CMMNDI>
+<?xml version="1.0" encoding="UTF-8"?>
+<cmmn:definitions xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC" xmlns="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" id="Def_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" exporter="Camunda Modeler" exporterVersion="1.4.0" author="">
+  <cmmn:case id="Case_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria">
+    <cmmn:casePlanModel id="CPM_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests" autoComplete="false">
+      <cmmn:planItem id="PI_HT_A" definitionRef="PID_PI_HT_A">
+        <cmmn:itemControl id="PlanItemControl_04sfv9q">
+          <cmmn:manualActivationRule id="ManualActivationRule_0bhlp3b">
+            <cmmn:condition id="Expression_1xj9lql">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+        <cmmn:exitCriterion id="N65556_exit1" sentryRef="On_PI_HT_B_ManualStart" />
+      </cmmn:planItem>
+      <cmmn:planItem id="PI_HT_B" definitionRef="PID_PI_HT_B">
+        <cmmn:itemControl id="PlanItemControl_0legxx7">
+          <cmmn:manualActivationRule id="ManualActivationRule_1t9b1rn">
+            <cmmn:condition id="Expression_0rmg3hz">${true}</cmmn:condition>
+          </cmmn:manualActivationRule>
+        </cmmn:itemControl>
+      </cmmn:planItem>
+      <cmmn:sentry id="On_PI_HT_B_ManualStart">
+        <cmmn:planItemOnPart id="f314d875-694b-40a1-a96c-d8c37084c0c4" sourceRef="PI_HT_B">        <cmmn:standardEvent>manualStart</cmmn:standardEvent>
+</cmmn:planItemOnPart>
+      </cmmn:sentry>
+      <cmmn:humanTask id="PID_PI_HT_A" name="A" />
+      <cmmn:humanTask id="PID_PI_HT_B" name="B" />
+    </cmmn:casePlanModel>
+  </cmmn:case>
+  <cmmndi:CMMNDI>
+    <cmmndi:CMMNDiagram sharedStyle="d4da590d-a61b-41d0-8f01-c62696eca972" id="PCPM_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests">
+      <cmmndi:Size xsi:type="dc:Dimension" width="642" height="500" />
+      <cmmndi:CMMNShape id="_f3ef863d-2098-4cb7-aa06-3068a4be1177" cmmnElementRef="CPM_TaskWithSentryExitCriteriaTest">
+        <dc:Bounds x="150" y="150" width="342" height="156" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_d9e77d80-719a-4f69-a43d-514d50206cf1" cmmnElementRef="PI_HT_A">
+        <dc:Bounds x="190" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_e423c7d5-81f7-4317-98f7-0d40ebe4037d" cmmnElementRef="PI_HT_B">
+        <dc:Bounds x="356" y="190" width="96" height="76" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNShape id="_4255c1ed-934b-413a-9b8c-57ae37be0391" cmmnElementRef="N65556_exit1">
+        <dc:Bounds x="276" y="214" width="20" height="28" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNShape>
+      <cmmndi:CMMNEdge id="_47fda588-082f-44f9-b7db-37a68a1a5f07" cmmnElementRef="f314d875-694b-40a1-a96c-d8c37084c0c4" targetCMMNElementRef="N65556_exit1" isStandardEventVisible="true">
+        <di:waypoint xsi:type="dc:Point" x="296" y="228" />
+        <di:waypoint xsi:type="dc:Point" x="356" y="228" />
+        <cmmndi:CMMNLabel />
+      </cmmndi:CMMNEdge>
+    </cmmndi:CMMNDiagram>
+    <cmmndi:CMMNStyle id="d4da590d-a61b-41d0-8f01-c62696eca972" fontFamily="Arial,Helvetica,sans-serif" />
+  </cmmndi:CMMNDI>
 </cmmn:definitions>
-

--- a/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTestExitCriteria.cmmn
+++ b/camunda-bpm-assert/src/test/resources/cmmn/TaskWithSentryTestExitCriteria.cmmn
@@ -1,21 +1,46 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<cmmn:definitions xmlns:cmmn="http://www.omg.org/spec/CMMN/20131201/MODEL" author="" exporter="CMMN Modeler"
-                  id="Def_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria"
-                  targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest">
-  <cmmn:case id="Case_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria">
-    <cmmn:casePlanModel autoComplete="false" description="" id="CPM_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests">
-      <cmmn:planItem definitionRef="HT_A" id="PI_HT_A" exitCriteriaRefs="On_PI_HT_B_ManualStart"/>
-      <cmmn:planItem definitionRef="HT_B" id="PI_HT_B"/>
-      <cmmn:sentry id="On_PI_HT_B_ManualStart">
-        <cmmn:planItemOnPart sourceRef="PI_HT_B">
-          <cmmn:standardEvent>manualStart</cmmn:standardEvent>
-        </cmmn:planItemOnPart>
-      </cmmn:sentry>
-      <cmmn:humanTask description="" id="HT_A" isBlocking="true" name="A">
-      </cmmn:humanTask>
-      <cmmn:humanTask description="" id="HT_B" isBlocking="true" name="B">
-      </cmmn:humanTask>
-    </cmmn:casePlanModel>
-  </cmmn:case>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cmmn:definitions author="" exporter="CMMN Modeler" id="Def_TaskWithSentryExitCriteriaTest" name="Task with Sentry Tests and Exit Criteria" targetNamespace="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" xmlns="http://www.trisotech.com/cmmn/definitions/_TaskWithSentryExitCriteriaTest" xmlns:trisob="http://www.trisotech.com/2014/triso/bpmn" xmlns:cmmndi="http://www.omg.org/spec/CMMN/20151109/CMMNDI" xmlns:rss="http://purl.org/rss/2.0/" xmlns:cmmn="http://www.omg.org/spec/CMMN/20151109/MODEL" xmlns:di="http://www.omg.org/spec/CMMN/20151109/DI" xmlns:trisofeed="http://trisotech.com/feed" xmlns:trisocmmn="http://www.trisotech.com/2014/triso/cmmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://www.omg.org/spec/CMMN/20151109/DC">
+    <cmmn:case name="Task with Sentry Tests and Exit Criteria" id="Case_TaskWithSentryExitCriteriaTest">
+        <cmmn:casePlanModel autoComplete="false" name="Task with Sentry Tests" id="CPM_TaskWithSentryExitCriteriaTest">
+            <cmmn:planItem definitionRef="PID_PI_HT_A" id="PI_HT_A">
+                <cmmn:exitCriterion sentryRef="On_PI_HT_B_ManualStart" id="N65556_exit1"/>
+            </cmmn:planItem>
+            <cmmn:planItem definitionRef="PID_PI_HT_B" id="PI_HT_B"/>
+            <cmmn:sentry id="On_PI_HT_B_ManualStart">
+                <cmmn:planItemOnPart sourceRef="PI_HT_B" id="f314d875-694b-40a1-a96c-d8c37084c0c4">
+                    <cmmn:standardEvent>manualStart</cmmn:standardEvent>
+                </cmmn:planItemOnPart>
+            </cmmn:sentry>
+            <cmmn:humanTask isBlocking="true" name="A" id="PID_PI_HT_A"/>
+            <cmmn:humanTask isBlocking="true" name="B" id="PID_PI_HT_B"/>
+        </cmmn:casePlanModel>
+    </cmmn:case>
+    <cmmndi:CMMNDI>
+        <cmmndi:CMMNDiagram name="Task with Sentry Tests" id="PCPM_TaskWithSentryExitCriteriaTest" sharedStyle="d4da590d-a61b-41d0-8f01-c62696eca972">
+            <cmmndi:Size height="500.0" width="642.0"/>
+            <cmmndi:CMMNShape cmmnElementRef="CPM_TaskWithSentryExitCriteriaTest" id="_f3ef863d-2098-4cb7-aa06-3068a4be1177">
+                <dc:Bounds height="156.0" width="342.0" x="150.0" y="150.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_A" id="_d9e77d80-719a-4f69-a43d-514d50206cf1">
+                <dc:Bounds height="76.0" width="96.0" x="190.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="PI_HT_B" id="_e423c7d5-81f7-4317-98f7-0d40ebe4037d">
+                <dc:Bounds height="76.0" width="96.0" x="356.0" y="190.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNShape cmmnElementRef="N65556_exit1" id="_4255c1ed-934b-413a-9b8c-57ae37be0391">
+                <dc:Bounds height="28.0" width="20.0" x="276.0" y="214.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNShape>
+            <cmmndi:CMMNEdge cmmnElementRef="f314d875-694b-40a1-a96c-d8c37084c0c4" isStandardEventVisible="true" targetCMMNElementRef="N65556_exit1" id="_47fda588-082f-44f9-b7db-37a68a1a5f07">
+                <di:waypoint x="296.0" y="228.0"/>
+                <di:waypoint x="356.0" y="228.0"/>
+                <cmmndi:CMMNLabel/>
+            </cmmndi:CMMNEdge>
+        </cmmndi:CMMNDiagram>
+        <cmmndi:CMMNStyle fontFamily="Arial,Helvetica,sans-serif" id="d4da590d-a61b-41d0-8f01-c62696eca972"/>
+    </cmmndi:CMMNDI>
 </cmmn:definitions>
 


### PR DESCRIPTION
Hi,

I have fixed the cmmn_assertions branch by adapting CMMN definitions and test cases to CMMN 1.1 behaviour (manual activation rule).

Cheers,
Stefan