### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <plugin.version.javadoc>3.1.1</plugin.version.javadoc>
     <!-- disable javadoc linter for JDK8 to not fail on incomplete javadoc -->
     <additionalparam>-Xdoclint:none</additionalparam>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,7 @@
           <configuration>
             <runOrder>hourly</runOrder>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <disableXmlReport>${closeTestReports}</disableXmlReport>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
